### PR TITLE
Correct spec failures for initial run of specs after loading tests data

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "engines"       : "*",
   "main"          : "js/stardog.js",
   "scripts"       : { 
-    "test" : "node_modules/jasmine-node/bin/jasmine-node spec" 
+    "test" : "sh load_test_data.sh && node_modules/jasmine-node/bin/jasmine-node spec" 
   }
 }

--- a/spec/query.spec.js
+++ b/spec/query.spec.js
@@ -27,7 +27,7 @@ describe ("Query a DB receiving a bind of results.", function() {
 			expect(data.results).toBeDefined();
 			expect(data.results.bindings).toBeDefined();
 			expect(data.results.bindings.length).toBeGreaterThan(0);
-			expect(data.results.bindings.length).toBe(2);
+			expect(data.results.bindings.length).toBe(3);
 			done();
 		});
 

--- a/spec/transactions.spec.js
+++ b/spec/transactions.spec.js
@@ -34,7 +34,7 @@ describe ("Getting and using transactions.", function() {
 				expect(data.results).toBeDefined();
 				expect(data.results.bindings).toBeDefined();
 				expect(data.results.bindings.length).toBeGreaterThan(0);
-				expect(data.results.bindings.length).toBe(2);
+				expect(data.results.bindings.length).toBe(3);
 
 				done();
 			});


### PR DESCRIPTION
Tests were failing immediately after loading into the Stardog database, but passing on subsequent tests.

I've updated the specs so that they correctly match the loaded data into Stardog immediately after a `load_test_data.sh`. I've also updated the NPM _test_ script/target so that it drops and reloads the test data each time the test suite is run. This is more in line with 'best practice' for integration tests.
