### PR TITLE
Set withCredentials:true on XmlHttpRequest to allow authenticated cross-domain requests (2)

### DIFF
--- a/js/stardog.js
+++ b/js/stardog.js
@@ -230,12 +230,23 @@
 			}
             headers['Accept'] = acceptH || "application/sparql-results+json";
 
+            function isCrossDomainRq(url) {
+                var a = document.createElement("a");
+                a.href=url;
+                return window.location.host != a.host;
+            }
+
+            var xhrFields = isCrossDomainRq(req_url) ? {
+                withCredentials: true
+            } : {};
+
 			$.ajax({
 				type: theMethod,
 				url: req_url,
 				dataType: 'json',
 				data: params,
 				headers: headers,
+                xhrFields : xhrFields,
 				success: function(data) {
 					var return_obj;
 


### PR DESCRIPTION
withCredentials:true is required for cross-domain authenticated requests.

On the server-side we need a reverse-proxy that should set the appropriate CORS headers:

Access-Control-Allow-Origin "list of comma separated urls from which requests are allow e.g. http://demo.org/"
Access-Control-Allow-Headers "accept, origin, sd-connection-string"
Access-Control-Allow-Methods "GET"
Access-Control-Allow-Credentials "true"

Unfortunately, if withCredentials is true, Access-Control-Allow-Origin CANNOT BE set to the wildcard (*) domain.

Here is an Apache config snippet to emulate it:

...
SetEnvIf Origin (.*) allow-origin-host=$1
Header set Access-Control-Allow-Origin "%{allow-origin-host}e"
...
