### PR TITLE
Propagate error message received from the server to the callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Stardog.js
 ==========
 
 Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)  
-_Current Version **0.0.3**_ 
+_Current Version **0.0.2**_ 
 
 Stardog.js JavaScript Framework for Node.js to develop apps with the [Stardog RDF Database](http://stardog.com).  
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"          : "stardog",
-  "version"       : "0.0.3",
+  "version"       : "0.0.2",
   "description"   : "Stardog.js JavaScript Framework for Node.js to develop apps with the Stardog RDF Database.",
   "homepage"      : "http://clarkparsia.github.com/stardog.js",
   "keywords"      : ["stardog", "rdf", "sparql", "library", "semantic web", "linked data"],


### PR DESCRIPTION
It is ofter useful for browser apps to show the error message received from the server. (e.g. the SPARQL query has a syntax error).
See an example at http://tools.ebusiness-unibw.org/tools/sparql-tutorial/ .
