### PR TITLE
Use HTTP POST for `query` and `queryGraph`

### DIFF
--- a/js/stardog.js
+++ b/js/stardog.js
@@ -513,24 +513,38 @@
         var reqOptions = {
             acceptHeader : options.mimetype || "application/sparql-results+json",
             resource: options.database + "/query",
-            httpMethod: "GET",
-            params : _.extend({ "query" : options.query }, options.params)
+            httpMethod: "POST",
+            params: {}
         };
 
         if (options.reasoning) {
             reqOptions.params["sd-connection-string"] = this._getSdConnectionString(options.reasoning);
         }
 
+        var queryParams = _.extend({ "query" : options.query }, options.params);
+
         if (options.baseURI) {
-            reqOptions.params.baseURI = options.baseURI;
+            queryParams.baseURI = options.baseURI;
         }
 
         if (options.limit) {
-            reqOptions.params.limit = options.limit;
+            queryParams.limit = options.limit;
         }
 
         if (options.offset) {
-            reqOptions.params.offset = options.offset;
+            queryParams.offset = options.offset;
+        }
+
+        if (!isNode) {
+            var formData = new window.FormData();
+            _.forIn(queryParams, function(value, key) {
+                formData.append(key, value);
+            });
+
+            reqOptions.msgBody = formData;
+        }
+        else {
+            reqOptions.msgBody = queryParams;
         }
 
         this._httpRequest(reqOptions, callback);
@@ -555,24 +569,38 @@
         var reqOptions = {
             acceptHeader : options.mimetype || "application/ld+json",
             resource: options.database + "/query",
-            httpMethod: "GET",
-            params : _.extend({ "query" : options.query }, options.params)
+            httpMethod: "POST",
+            params: {}
         };
 
         if (options.reasoning) {
             reqOptions.params["sd-connection-string"] = this._getSdConnectionString(options.reasoning);
         }
 
+        var queryParams = _.extend({ "query" : options.query }, options.params);
+
         if (options.baseURI) {
-            reqOptions.params.baseURI = options.baseURI;
+            queryParams.baseURI = options.baseURI;
         }
 
         if (options.limit) {
-            reqOptions.params.limit = options.limit;
+            queryParams.limit = options.limit;
         }
 
         if (options.offset) {
-            reqOptions.params.offset = options.offset;
+            queryParams.offset = options.offset;
+        }
+
+        if (!isNode) {
+            var formData = new window.FormData();
+            _.forIn(queryParams, function(value, key) {
+                formData.append(key, value);
+            });
+
+            reqOptions.msgBody = formData;
+        }
+        else {
+            reqOptions.msgBody = queryParams;
         }
 
         this._httpRequest(reqOptions, callback);

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -56,6 +56,67 @@
             });
         });
 
+        it ("A query result should not have more bindings than its intended limit", function(done) {
+            conn.onlineDB({ database: "nodeDB", strategy: "NO_WAIT" }, function () {
+
+                conn.query({ 
+                    database: "nodeDB",
+                    query: "select * where { ?s ?p ?o }",
+                    limit: 10, 
+                    offset: 0 
+                }, function (data) {
+                    //console.log(data);
+
+                    expect(data).not.to.be(null);
+                    expect(data.results).not.to.be(undefined);
+                    expect(data.results.bindings).not.to.be(undefined);
+                    expect(data.results.bindings.length).to.be.above(0);
+                    expect(data.results.bindings.length).to.be(10);
+                    done();
+                });
+            });
+        });
+
+        it ("The baseURI option should be applied to the query", function(done) {
+            conn.onlineDB({ database: "nodeDB", strategy: "NO_WAIT" }, function () {
+
+                conn.query({ 
+                    database: "nodeDB",
+                    query: "select * where { <Article1> ?p ?o }",
+                    baseURI: "http://localhost/publications/articles/Journal1/1940/",
+                    limit: 10, 
+                    offset: 0 
+                }, function (data) {
+                    //console.log(data);
+
+                    expect(data).not.to.be(null);
+                    expect(data.results).not.to.be(undefined);
+                    expect(data.results.bindings).not.to.be(undefined);
+                    expect(data.results.bindings.length).to.be.above(0);
+                    done();
+                });
+            });
+        });
+
+        it ("Very long queries should be OK", function(done) {
+            conn.onlineDB({ database: "nodeDB", strategy: "NO_WAIT" }, function () {
+
+                conn.query({ 
+                    database: "nodeDB",
+                    query: "select * where { <http://localhost/publications/articles/Journal1/1940/Article1> ?p \"unmuzzling measles decentralizing hogfishes gantleted richer succories dwelling scrapped prat islanded burlily thanklessly swiveled polers oinked apnea maxillary dumpers bering evasiveness toto teashop reaccepts gunneries exorcises pirog desexes summable heliocentricity excretions recelebrating dually plateauing reoccupations embossers cerebrum gloves mohairs admiralties bewigged playgoers cheques batting waspishly stilbestrol villainousness miscalling firefanged skeins equalled sandwiching bewitchment cheaters riffled kerneling napoleons rifer unmuzzling measles decentralizing hogfishes gantleted richer succories dwelling scrapped prat islanded burlily thanklessly swiveled polers oinked apnea maxillary dumpers bering evasiveness toto teashop reaccepts gunneries exorcises pirog desexes summable heliocentricity excretions recelebrating dually plateauing reoccupations embossers cerebrum gloves mohairs admiralties bewigged playgoers cheques batting waspishly stilbestrol villainousness miscalling firefanged skeins equalled sandwiching bewitchment cheaters riffled kerneling napoleons rifer unmuzzling measles decentralizing hogfishes gantleted richer succories dwelling scrapped prat islanded burlily thanklessly swiveled polers oinked apnea maxillary dumpers bering evasiveness toto teashop reaccepts gunneries exorcises pirog desexes summable heliocentricity excretions recelebrating dually plateauing reoccupations embossers cerebrum gloves mohairs admiralties bewigged playgoers cheques batting waspishly stilbestrol villainousness miscalling firefanged skeins equalled sandwiching bewitchment cheaters riffled kerneling napoleons rifer unmuzzling measles decentralizing hogfishes gantleted richer succories dwelling scrapped prat islanded burlily thanklessly swiveled polers oinked apnea maxillary dumpers bering evasiveness toto teashop reaccepts gunneries exorcises pirog desexes summable heliocentricity excretions recelebrating dually plateauing reoccupations embossers cerebrum gloves mohairs admiralties bewigged playgoers cheques batting waspishly stilbestrol villainousness miscalling firefanged skeins equalled sandwiching bewitchment cheaters riffled kerneling napoleons rifer unmuzzling measles decentralizing hogfishes gantleted richer succories dwelling scrapped prat islanded burlily thanklessly swiveled polers oinked apnea maxillary dumpers bering evasiveness toto teashop reaccepts gunneries exorcises pirog desexes summable heliocentricity excretions recelebrating dually plateauing reoccupations embossers cerebrum gloves mohairs admiralties bewigged playgoers cheques batting waspishly stilbestrol villainousness miscalling firefanged skeins equalled sandwiching bewitchment cheaters riffled kerneling napoleons rifer unmuzzling measles decentralizing hogfishes gantleted richer succories dwelling scrapped prat islanded burlily thanklessly swiveled polers oinked apnea maxillary burlily thanklessly swiveled polers oinked apnea maxillary burlily thanklessly swiveled polers oinked apnea maxillary\" }",
+                    limit: 1, 
+                    offset: 0 
+                }, function (data) {
+                    // console.log(data);
+
+                    expect(data).not.to.be(null);
+                    expect(data.results).not.to.be(undefined);
+                    expect(data.results.bindings).not.to.be(undefined);
+                    expect(data.results.bindings.length).to.be(0);
+                    done();
+                });
+            });
+        });
     });
 
     describe ("Query a DB with QL reasoning receiving a bind of results.", function() {


### PR DESCRIPTION
(Re: #35)
- The `httpMethod` for `_httpRequest` in `query` and `queryGraph` is
  POST instead of GET to allow for longer queries which would otherwise
  time out.
- `query`, `baseURI`, `limit`, `offset` parameters are passed as POST
  `msgBody`. For browser, `msgBody` uses the window.FormData class,
  following the `createDb` method.
- Additional test suites created for longer queries and for testing
  whether offset & baseURI parameters work through POST.
