### PR TITLE
Early phasing of migrating to fetch.

### DIFF
--- a/lib/dbopts.js
+++ b/lib/dbopts.js
@@ -1,0 +1,165 @@
+// These are the Stardog DB options that I know about as of 2017-06-29.
+// I got this list by running `stardog-admin metadata get <DATABASE>`
+
+module.exports = {
+  database: {
+    archetypes: null,
+    connection: {
+      timeout: null,
+    },
+    creator: null,
+    name: null,
+    namespaces: null,
+    online: null,
+    time: {
+      creation: null,
+    },
+  },
+  docs: {
+    default: {
+      rdf: {
+        extractors: null,
+      },
+      text: {
+        extractors: null,
+      },
+    },
+    filesystem: {
+      uri: null,
+    },
+    path: null,
+  },
+  icv: {
+    active: {
+      graphs: null,
+    },
+    consistency: {
+      automatic: null,
+    },
+    enabled: null,
+    reasoning: {
+      enabled: null,
+    },
+  },
+  index: {
+    differential: {
+      enable: {
+        limit: null,
+      },
+      merge: {
+        limit: null,
+      },
+      size: null,
+    },
+    disk: {
+      page: {
+        count: {
+          total: null,
+          used: null,
+        },
+        fill: {
+          ratio: null,
+        },
+      },
+    },
+    last: {
+      tx: null,
+    },
+    literals: {
+      canonical: null,
+    },
+    named: {
+      graphs: null,
+    },
+    persist: null,
+    size: null,
+    statistics: {
+      update: {
+        automatic: null,
+      },
+    },
+    type: null,
+  },
+  preserve: {
+    bnode: {
+      ids: null,
+    },
+  },
+  progress: {
+    monitor: {
+      enabled: null,
+    },
+  },
+  query: {
+    all: {
+      graphs: null,
+    },
+    plan: {
+      reuse: null,
+    },
+    timeout: null,
+  },
+  reasoning: {
+    approximate: null,
+    classify: {
+      eager: null,
+    },
+    consistency: {
+      automatic: null,
+    },
+    punning: {
+      enabled: null,
+    },
+    sameas: null,
+    schema: {
+      graphs: null,
+      timeout: null,
+    },
+    type: null,
+    virtual: {
+      graph: {
+        enabled: null,
+      },
+    },
+  },
+  search: {
+    default: {
+      limit: null,
+    },
+    enabled: null,
+    index: {
+      datatypes: null,
+    },
+    reindex: {
+      tx: null,
+    },
+    wildcard: {
+      search: {
+        enabled: null,
+      },
+    },
+  },
+  security: {
+    named: {
+      graphs: null,
+    },
+  },
+  spatial: {
+    enabled: null,
+    index: {
+      version: null,
+    },
+    precision: null,
+  },
+  strict: {
+    parsing: null,
+  },
+  transaction: {
+    isolation: null,
+    logging: null,
+  },
+  versioning: {
+    directory: null,
+    enabled: null,
+  },
+};

--- a/lib/index2.js
+++ b/lib/index2.js
@@ -1,0 +1,238 @@
+const { fetch, Headers } = require('fetch-ponyfill')();
+const base64 = require('isomorphic-base64');
+const qs = require('querystring');
+const _ = require('lodash');
+const flat = require('flat');
+// TODO: what to do about native FormData in the browser? Might need two index files and do DI
+const FormData = require('form-data');
+const pkg = require('../package.json');
+const DB_OPTIONS = require('./dbopts');
+
+const DEFAULTS = {
+  reasoning: false,
+};
+
+const Stardog = {
+  version: pkg.version,
+};
+
+const uri = (...args) => args.join('/');
+const HTTPMessage = res => ({
+  status: res.status,
+  statusText: res.statusText,
+});
+const ResponseBody = res => {
+  const contentType = res.headers.get('content-type');
+  // TODO:
+  // I'll need to look at this again because the response isn't always application/json
+  if (contentType && contentType.indexOf('json') > -1) {
+    return res.json().then(result => {
+      return {
+        result,
+        status: res.status,
+        statusText: res.statusText,
+      };
+    });
+  } else {
+    return res.text().then(result => {
+      return {
+        result,
+        status: res.status,
+        statusText: res.statusText,
+      };
+    });
+  }
+};
+
+const AuthorizationHeaders = (username, password) => {
+  const headers = new Headers();
+  headers.append(
+    'Authorization',
+    'Basic ' + base64.btoa(username + ':' + password)
+  );
+  headers.append('Accept', '*/*');
+  return headers;
+};
+
+class Connection {
+  constructor(options = {}) {
+    this.config(options);
+  }
+
+  config(options) {
+    const config = Object.assign({}, DEFAULTS, this, options);
+
+    // If it ends with / slice it off
+    if (
+      config.endpoint &&
+      config.endpoint.lastIndexOf('/') === config.endpoint.length - 1
+    ) {
+      config.endpoint = config.endpoint.slice(0, -1);
+    }
+
+    this.endpoint = config.endpoint;
+    this.reasoning = config.reasoning;
+    this.username = config.username;
+    this.password = config.password;
+    this.database = config.database;
+  }
+
+  createDB(database, databaseOptions, options, params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    const dbOptions = flat(databaseOptions);
+
+    const body = new FormData();
+    body.append(
+      'root',
+      JSON.stringify({
+        dbname: database,
+        options: dbOptions,
+        files: options.files,
+      })
+    );
+
+    return fetch(uri(this.endpoint, 'admin/databases'), {
+      method: 'POST',
+      headers,
+      body,
+      credentials: 'include',
+    }).then(HTTPMessage);
+  }
+
+  dropDB(database, params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    return fetch(uri(this.endpoint, 'admin', 'databases', database), {
+      method: 'DELETE',
+      headers,
+    }).then(HTTPMessage);
+  }
+
+  getDB(database, params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    return fetch(uri(this.endpoint, database), {
+      headers,
+    }).then(ResponseBody);
+  }
+
+  getDBOptions(database, params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    headers.append('Content-Type', 'application/json');
+    return fetch(
+      uri(this.endpoint, 'admin', 'databases', database, 'options'),
+      {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(flat(DB_OPTIONS)),
+      }
+    )
+      .then(ResponseBody)
+      .then(res => {
+        if (res.status === 200) {
+          return Object.assign({}, res, {
+            result: flat.unflatten(res.result),
+          });
+        }
+        return res;
+      });
+  }
+
+  offlineDB(database, params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    headers.append('Accept', 'application/json');
+    return fetch(
+      uri(this.endpoint, 'admin', 'databases', database, 'offline'),
+      {
+        method: 'PUT',
+        headers,
+      }
+    ).then(ResponseBody);
+  }
+
+  onlineDB(database, params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    headers.append('Accept', 'application/json');
+    return fetch(uri(this.endpoint, 'admin', 'databases', database, 'online'), {
+      method: 'PUT',
+      headers,
+    }).then(ResponseBody);
+  }
+
+  copyDB(database, destination, params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    headers.append('Accept', 'application/json');
+    const resource = `${uri(
+      this.endpoint,
+      'admin',
+      'databases',
+      database,
+      'copy'
+    )}?${qs.stringify({ to: destination })}`;
+    return fetch(resource, {
+      method: 'PUT',
+      headers,
+    }).then(ResponseBody);
+  }
+
+  listDBs(params) {
+    const headers = AuthorizationHeaders(this.username, this.password);
+    headers.append('Accept', 'application/json');
+    return fetch(uri(this.endpoint, 'admin', 'databases'), {
+      headers,
+    }).then(ResponseBody);
+  }
+
+  getProperty(options, params) {
+    return this.query(
+      {
+        database: options.database,
+        query: `select * where {
+        ${options.uri} ${options.property} ?val
+        }
+    `,
+      },
+      params
+    ).then(res => {
+      const values = _.get(res, 'result.results.bindings', []);
+      if (values.length > 0) {
+        return Object.assign({}, res, {
+          result: values[0].val.value,
+        });
+      }
+    });
+  }
+
+  query(options, params) {
+    // Merge optoins with this, so you can overwrite specific options on a per call basis
+    const config = Object.assign({}, this, options);
+    const queryParams = ['baseURI', 'limit', 'offset', 'reasoning'];
+
+    const headers = AuthorizationHeaders(this.username, this.password);
+    headers.append('Accept', 'application/sparql-results+json');
+    headers.append('Content-Type', 'application/x-www-form-urlencoded');
+
+    const body = {
+      query: options.query,
+    };
+
+    const database = options.database || this.database;
+
+    Object.keys(config)
+      // If it's a supported query param and it has a value, include it
+      .filter(v => queryParams.indexOf(v) > -1 && config[v] != null)
+      .reduce((memo, key) => {
+        memo[key] = config[key];
+        return memo;
+      }, body);
+
+    return fetch(uri(this.endpoint, database, 'query'), {
+      method: 'POST',
+      body: qs.stringify(body),
+      credentials: 'include',
+      headers,
+    }).then(ResponseBody);
+  }
+}
+
+Stardog.Connection = Connection;
+
+module.exports = Stardog;

--- a/package.json
+++ b/package.json
@@ -65,11 +65,16 @@
     "url": "https://github.com/stardog-union/stardog.js/issues"
   },
   "dependencies": {
-    "lodash": "~2.4.1",
-    "querystring": "~0.2.0",
+    "fetch-ponyfill": "^4.0.0",
+    "flat": "^2.0.1",
+    "form-data": "^2.2.0",
+    "isomorphic-base64": "^1.0.2",
+    "lodash": "^4.17.4",
+    "querystring": "^0.2.0",
     "restler": "~3.2.2"
   },
   "devDependencies": {
+    "@types/jest": "^20.0.2",
     "husky": "^0.13.4",
     "jest": "^20.0.4",
     "lint-staged": "^4.0.0",
@@ -88,5 +93,6 @@
       "prettier --single-quote --trailing-comma es5 --write",
       "git add"
     ]
-  }
+  },
+  "stardog-version": ">=5.0.0"
 }

--- a/test/Connection.spec.js
+++ b/test/Connection.spec.js
@@ -1,0 +1,49 @@
+const { Connection } = require('../lib/index2');
+
+describe('Stardog.Connection', () => {
+  it('creates a new connection object', () => {
+    const c = new Connection();
+    expect(c).toBeInstanceOf(Connection);
+  });
+
+  it('creates a new connection object with options', () => {
+    const c = new Connection({
+      username: 'admin',
+      password: 'admin',
+      endpoint: 'http://localhost:5820/DB/',
+      reasoning: false,
+    });
+    expect(c).toMatchObject({
+      username: 'admin',
+      password: 'admin',
+      endpoint: 'http://localhost:5820/DB',
+      reasoning: false,
+    });
+  });
+
+  describe('config()', () => {
+    it('overwrites existing config options', () => {
+      const c = new Connection({
+        username: 'admin',
+        password: 'foo',
+      });
+      expect(c).toMatchObject({
+        username: 'admin',
+        password: 'foo',
+        endpoint: undefined,
+        reasoning: false,
+      });
+      c.config({
+        username: 'adam',
+        password: 'admin',
+        endpoint: 'http://localhost:3000/DB',
+      });
+      expect(c).toMatchObject({
+        username: 'adam',
+        password: 'admin',
+        endpoint: 'http://localhost:3000/DB',
+        reasoning: false,
+      });
+    });
+  });
+});

--- a/test/copyDB.spec.js
+++ b/test/copyDB.spec.js
@@ -1,4 +1,4 @@
-const Stardog = require('../lib');
+const Stardog = require('../lib/index2');
 const {
   seedDatabase,
   dropDatabase,
@@ -15,48 +15,34 @@ describe('copyDB()', () => {
   afterAll(dropDatabase(destinationDatabase));
 
   beforeEach(() => {
-    conn = new Stardog.Connection();
-    conn.setEndpoint('http://localhost:5820/');
-    conn.setCredentials('admin', 'admin');
+    conn = new Stardog.Connection({
+      username: 'admin',
+      password: 'admin',
+      endpoint: 'http://localhost:5820/',
+    });
   });
 
-  it('should not copy an online DB', done => {
-    conn.onlineDB(
-      { dbsource: sourceDatabase, strategy: 'WAIT', timeout: 3 },
-      () => {
-        conn.copyDB(
-          { dbsource: sourceDatabase, dbtarget: destinationDatabase },
-          () => {
-            conn.listDBs((data, res) => {
-              expect(res.statusCode).toEqual(200); // Not sure why this is a 200, but it is
-              expect(data.databases).not.toContain(destinationDatabase);
-              expect(data.databases).toContain(sourceDatabase);
-              done();
-            });
-          }
-        );
-      }
-    );
+  it('should not copy an online DB', () => {
+    return conn
+      .copyDB(sourceDatabase, destinationDatabase)
+      .then(conn.listDBs.bind(conn))
+      .then(res => {
+        expect(res.status).toEqual(200);
+        // Destination shouldn't be listed because it's not online yet and therefor didn't get copied.
+        expect(res.result.databases).not.toContain(destinationDatabase);
+        expect(res.result.databases).toContain(sourceDatabase);
+      });
   });
 
-  it('should copy an offline DB', done => {
-    conn.offlineDB(
-      { database: sourceDatabase, strategy: 'WAIT', timeout: 3 },
-      () => {
-        // Once the DB is offline, copy it.
-        conn.copyDB(
-          { dbsource: sourceDatabase, dbtarget: destinationDatabase },
-          () => {
-            conn.listDBs((data, res) => {
-              expect(res.statusCode).toEqual(200);
-              expect(data.databases).toEqual(
-                expect.arrayContaining([sourceDatabase, destinationDatabase])
-              );
-              done();
-            });
-          }
-        );
-      }
-    );
+  it('should copy an offline DB', () => {
+    return conn
+      .offlineDB(sourceDatabase)
+      .then(conn.copyDB.bind(conn, sourceDatabase, destinationDatabase))
+      .then(conn.listDBs.bind(conn))
+      .then(res => {
+        expect(res.status).toEqual(200);
+        expect(res.result.databases).toContain(destinationDatabase);
+        expect(res.result.databases).toContain(sourceDatabase);
+      });
   });
 });

--- a/test/getDB.spec.js
+++ b/test/getDB.spec.js
@@ -1,4 +1,4 @@
-const Stardog = require('../lib');
+const Stardog = require('../lib/index2');
 const {
   seedDatabase,
   dropDatabase,
@@ -14,16 +14,17 @@ describe('getDB()', () => {
   afterAll(dropDatabase(database));
 
   beforeEach(() => {
-    conn = new Stardog.Connection();
-    conn.setEndpoint('http://localhost:5820/');
-    conn.setCredentials('admin', 'admin');
+    conn = new Stardog.Connection({
+      username: 'admin',
+      password: 'admin',
+      endpoint: 'http://localhost:5820',
+    });
   });
 
-  it('A response of the DB info should not be empty', done => {
-    conn.getDB({ database }, (data, response) => {
-      expect(data.length).toBeGreaterThan(0);
-      expect(response.statusCode).toEqual(200);
-      done();
+  it('A response of the DB info should not be empty', () => {
+    return conn.getDB(database).then(res => {
+      expect(res.result).toMatch('@prefix : <http://example.org/vehicles/> .');
+      expect(res.status).toEqual(200);
     });
   });
 });

--- a/test/getDBOptions.spec.js
+++ b/test/getDBOptions.spec.js
@@ -1,4 +1,4 @@
-const Stardog = require('../lib');
+const Stardog = require('../lib/index2');
 const {
   seedDatabase,
   dropDatabase,
@@ -14,45 +14,30 @@ describe('getDBOptions()', () => {
   afterAll(dropDatabase(database));
 
   beforeEach(() => {
-    conn = new Stardog.Connection();
-    conn.setEndpoint('http://localhost:5820/');
-    conn.setCredentials('admin', 'admin');
-  });
-
-  it('should get NOT_FOUND status code trying to get the options of a non-existent DB.', done => {
-    const optionsObj = {
-      'search.enabled': '',
-      'icv.enabled': '',
-    };
-
-    conn.onlineDB({ database: 'nodeDB_test' }, (dataOnline, res) => {
-      expect(res.statusCode).toEqual(404);
-      conn.getDBOptions(
-        { database: 'nodeDB_test', optionsObj: optionsObj },
-        (data, res) => {
-          expect(res.statusCode).toEqual(404);
-          done();
-        }
-      );
+    conn = new Stardog.Connection({
+      username: 'admin',
+      password: 'admin',
+      endpoint: 'http://localhost:5820/',
     });
   });
 
-  it('should get the options of an DB', done => {
-    const optionsObj = {
-      'search.enabled': '',
-      'icv.enabled': '',
-    };
+  it('should get NOT_FOUND status code trying to get the options of a non-existent DB.', () => {
+    return conn.getDBOptions('nodeDB_test').then(res => {
+      expect(res.status).toEqual(404);
+    });
+  });
 
-    conn.getDBOptions(
-      { database, optionsObj: optionsObj },
-      (data, respose2) => {
-        expect(respose2.statusCode).toEqual(200);
-        expect(data).toEqual({
-          'search.enabled': true,
-          'icv.enabled': false,
-        });
-        done();
-      }
-    );
+  it('should get the options of an DB', () => {
+    return conn.getDBOptions(database).then(res => {
+      expect(res.status).toEqual(200);
+      expect(res.result).toMatchObject({
+        search: {
+          enabled: true,
+        },
+        index: {
+          type: 'Disk',
+        },
+      });
+    });
   });
 });

--- a/test/getProperty.spec.js
+++ b/test/getProperty.spec.js
@@ -1,4 +1,4 @@
-const Stardog = require('../lib');
+const Stardog = require('../lib/index2');
 const {
   seedDatabase,
   dropDatabase,
@@ -14,24 +14,24 @@ describe('getProperty()', () => {
   afterAll(dropDatabase(database));
 
   beforeEach(() => {
-    conn = new Stardog.Connection();
-    conn.setEndpoint('http://localhost:5820/');
-    conn.setCredentials('admin', 'admin');
+    conn = new Stardog.Connection({
+      username: 'admin',
+      password: 'admin',
+      endpoint: 'http://localhost:5820',
+      database,
+    });
   });
 
-  it('Gets a specific property from the database', done => {
-    conn.getProperty(
-      {
-        database,
+  it('Gets a specific property from the database', () => {
+    return conn
+      .getProperty({
         uri: '<http://localhost/publications/articles/Journal1/1940/Article1>',
         property: '<http://localhost/vocabulary/bench/cdrom>',
-      },
-      response => {
-        expect(response).toEqual(
+      })
+      .then(res => {
+        expect(res.result).toEqual(
           'http://www.hogfishes.tld/richer/succories.html'
         );
-        done();
-      }
-    );
+      });
   });
 });

--- a/test/setup-database.js
+++ b/test/setup-database.js
@@ -1,56 +1,64 @@
 const Path = require('path');
 const RandomString = require('randomstring');
-const Stardog = require('../lib');
+const Stardog = require('../lib/index2');
 const dbs = new Set(); // used to keep track of DBs across runs
 
-exports.seedDatabase = database => done => {
-  const conn = new Stardog.Connection();
-  conn.setEndpoint('http://localhost:5820/');
-  conn.setCredentials('admin', 'admin');
-  conn.createDB(
-    {
+exports.seedDatabase = database => () => {
+  const conn = new Stardog.Connection({
+    username: 'admin',
+    password: 'admin',
+    endpoint: 'http://localhost:5820',
+  });
+
+  return conn
+    .createDB(
       database,
-      options: {
-        'index.type': 'disk',
-        'search.enabled': true,
+      {
+        index: {
+          type: 'disk',
+        },
+        search: {
+          enabled: true,
+        },
       },
-      // Load everything into the DB
-      files: [
-        {
-          filename: Path.resolve(__dirname, 'fixtures', 'api_tests.nt'),
-        },
-        {
-          filename: Path.resolve(
-            __dirname,
-            'fixtures',
-            'reasoning',
-            'abox.ttl'
-          ),
-        },
-        {
-          filename: Path.resolve(
-            __dirname,
-            'fixtures',
-            'reasoning',
-            'tbox.ttl'
-          ),
-        },
-      ],
-    },
-    (data, response) => {
-      expect(response.statusCode).toBe(201);
-      done();
-    }
-  );
+      {
+        // Load everything into the DB
+        files: [
+          {
+            filename: Path.resolve(__dirname, 'fixtures', 'api_tests.nt'),
+          },
+          {
+            filename: Path.resolve(
+              __dirname,
+              'fixtures',
+              'reasoning',
+              'abox.ttl'
+            ),
+          },
+          {
+            filename: Path.resolve(
+              __dirname,
+              'fixtures',
+              'reasoning',
+              'tbox.ttl'
+            ),
+          },
+        ],
+      }
+    )
+    .then(res => {
+      expect(res.status).toBe(201);
+    });
 };
 
-exports.dropDatabase = database => done => {
-  const conn = new Stardog.Connection();
-  conn.setEndpoint('http://localhost:5820/');
-  conn.setCredentials('admin', 'admin');
-  conn.dropDB({ database }, (data, response) => {
-    expect(response.statusCode).toBe(200);
-    done();
+exports.dropDatabase = database => () => {
+  const conn = new Stardog.Connection({
+    username: 'admin',
+    password: 'admin',
+    endpoint: 'http://localhost:5820',
+  });
+  return conn.dropDB(database).then(res => {
+    expect(response.status).toBe(200);
   });
 };
 


### PR DESCRIPTION
Stopping here to get feedback from others. Currently, the following tests all
pass:

PASS  test/copyDB.spec.js
PASS  test/Connection.spec.js
PASS  test/query.spec.js
PASS  test/getProperty.spec.js
PASS  test/getDB.spec.js
PASS  test/getDBOptions.spec.js

---

## Commentary

For now, I'm keeping the old index.js file around for reference as it's easier to look at that then to try to figure out HTTP calls to the server. 

One thing I'd like to comment on is `params`. All of the methods that hit the HTTP server have `params` as a final argument. The intent there is to (eventually) allow users to pass any additional query parameters along. As I don't know what they could possibly be, I haven't really explored what they could be, but that's why it's there but not currently used.

Regarding my `FormData` TODO comment... all of these test are currently running under the node context and are working. In jest you can pass the `--browser` flag which will cause the `require` system to honor the "browser" field in package.json when it tries to load things in. This will give you the browser version of modules that have that set up. Going down that execution path, we end up using jsdom's version of an `XMLHTTPRequest`. Per this comment here https://github.com/tmpvar/jsdom/blob/7d950c448fda038c8c385e5fba07fd85bd19326e/lib/jsdom/living/xmlhttprequest.js#L578-L579, I feel like multipart form data with proper content-type and boundary headers do not work with the version of jsdom that jest is currently using. This matters because... when the fetch pony fill I'm using fires up, going down the browser path, it implements the `fetch` API via promises and `XMLHTTPRequests`. That means it's using the incomplete jsdom version and NOT a full browser implementation. I am confident that running this code, properly bundled, in a browser would function. The only API that's even remotely complex is creating a DB, everything else is simple. The issue is that EVERY tests uses the create database API so if that doesn't work, none of the tests work.

The *TL;DR* is, I'm going to continue writing and running tests against Node for now with the understanding that we're going to have to revisit this. To this point, that weird multi-part form data thing is the ONLY spot where we have issue between node and browser.