### PR TITLE
🛁 - Update create arguments

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -14,7 +14,7 @@ const create = (conn, user, params) => {
   headers.append('Content-Type', 'application/json');
 
   const body = {
-    username: user.username,
+    username: user.name,
     password: user.password.split(''),
     superuser: typeof user.superuser === 'boolean' ? user.superuser : false,
   };

--- a/test/assignPermissionToUser.spec.js
+++ b/test/assignPermissionToUser.spec.js
@@ -31,7 +31,7 @@ describe('assignPermissionToUser()', () => {
   });
 
   it('should pass assinging a Permissions to a new user.', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
     const permission = {
       action: 'write',
@@ -41,12 +41,12 @@ describe('assignPermissionToUser()', () => {
 
     return user
       .create(conn, {
-        username,
+        name,
         password,
       })
       .then(res => {
         expect(res.status).toBe(201);
-        return user.assignPermission(conn, username, permission);
+        return user.assignPermission(conn, name, permission);
       })
       .then(res => {
         expect(res.status).toBe(201);

--- a/test/changePwd.spec.js
+++ b/test/changePwd.spec.js
@@ -15,24 +15,24 @@ describe('changePwd()', () => {
   });
 
   it('should change the password and allow calls with new credentials', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
     const newPassword = generateRandomString();
     return user
       .create(conn, {
-        username,
+        name,
         password,
         superuser: true,
       })
       .then(res => {
         expect(res.status).toEqual(201);
-        return user.changePassword(conn, username, newPassword);
+        return user.changePassword(conn, name, newPassword);
       })
       .then(res => {
         expect(res.status).toEqual(200);
         // Switch to new user
         conn.config({
-          username,
+          username: name,
           password: newPassword,
         });
         return db.list(conn);

--- a/test/deletePermissionFromUser.spec.js
+++ b/test/deletePermissionFromUser.spec.js
@@ -31,7 +31,7 @@ describe('deletePermissionFromUser()', () => {
   });
 
   it('should pass deleting a Permissions to a new user.', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
     const permission = {
       action: 'write',
@@ -41,16 +41,16 @@ describe('deletePermissionFromUser()', () => {
 
     return user
       .create(conn, {
-        username,
+        name,
         password,
       })
       .then(res => {
         expect(res.status).toBe(201);
-        return user.assignPermission(conn, username, permission);
+        return user.assignPermission(conn, name, permission);
       })
       .then(res => {
         expect(res.status).toBe(201);
-        return user.deletePermission(conn, username, permission);
+        return user.deletePermission(conn, name, permission);
       })
       .then(res => {
         expect(res.status).toBe(201);

--- a/test/deleteUser.spec.js
+++ b/test/deleteUser.spec.js
@@ -15,15 +15,15 @@ describe('deleteUser()', () => {
   });
 
   it('should delete a supplied user recently created.', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     return user
       .create(conn, {
-        username,
+        name,
         password: generateRandomString(),
       })
       .then(res => {
         expect(res.status).toBe(201);
-        return user.delete(conn, username);
+        return user.delete(conn, name);
       })
       .then(res => {
         expect(res.status).toBe(204);

--- a/test/isSuperUser.spec.js
+++ b/test/isSuperUser.spec.js
@@ -27,18 +27,18 @@ describe('isSuperUser()', () => {
   });
 
   it("should return the value with the user's superuser flag (false)", () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
 
     return user
       .create(conn, {
-        username,
+        name,
         password,
         superuser: false,
       })
       .then(res => {
         expect(res.status).toBe(201);
-        return user.superUser(conn, username);
+        return user.superUser(conn, name);
       })
       .then(res => {
         expect(res.result.superuser).toBe(false);

--- a/test/isUserEnabled.spec.js
+++ b/test/isUserEnabled.spec.js
@@ -27,19 +27,19 @@ describe('user.enabled()', () => {
   });
 
   it("should return the value with the user's superuser flag (false)", () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
 
     return user
       .create(conn, {
-        username,
+        name,
         password,
       })
       .then(res => {
         expect(res.status).toEqual(201);
-        return user.enable(conn, username, false);
+        return user.enable(conn, name, false);
       })
-      .then(() => user.enabled(conn, username))
+      .then(() => user.enabled(conn, name))
       .then(res => {
         expect(res.result.enabled).toEqual(false);
       });

--- a/test/listUserEffPermissions.spec.js
+++ b/test/listUserEffPermissions.spec.js
@@ -25,7 +25,7 @@ describe('listUserEffPermissions()', () => {
   });
 
   it('should list effective permissions assigned to a new user.', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
     const permission = {
       action: 'write',
@@ -35,11 +35,11 @@ describe('listUserEffPermissions()', () => {
 
     return user
       .create(conn, {
-        username,
+        name,
         password,
       })
-      .then(() => user.assignPermission(conn, username, permission))
-      .then(() => user.effectivePermissions(conn, username))
+      .then(() => user.assignPermission(conn, name, permission))
+      .then(() => user.effectivePermissions(conn, name))
       .then(res => {
         expect(res.result.permissions.length).toBeGreaterThan(0);
         expect(res.result.permissions).toContainEqual({

--- a/test/listUserPermissions.spec.js
+++ b/test/listUserPermissions.spec.js
@@ -25,7 +25,7 @@ describe('listUserPermissions()', () => {
   });
 
   it('should list permissions assigned to a new user.', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
     const permission = {
       action: 'write',
@@ -35,11 +35,11 @@ describe('listUserPermissions()', () => {
 
     return user
       .create(conn, {
-        username,
+        name,
         password,
       })
-      .then(() => user.assignPermission(conn, username, permission))
-      .then(() => user.permissions(conn, username))
+      .then(() => user.assignPermission(conn, name, permission))
+      .then(() => user.permissions(conn, name))
       .then(res => {
         expect(res.status).toBe(200);
         const resources = res.result.permissions.reduce(

--- a/test/setUserRoles.spec.js
+++ b/test/setUserRoles.spec.js
@@ -15,17 +15,17 @@ describe('Set User Roles Test Suite', () => {
   });
 
   it('should assign roles to a newly created user.', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
     return user
       .create(conn, {
-        username,
+        name,
         password,
       })
-      .then(() => user.setRoles(conn, username, ['reader']))
+      .then(() => user.setRoles(conn, name, ['reader']))
       .then(res => {
         expect(res.status).toBe(200);
-        return user.listRoles(conn, username);
+        return user.listRoles(conn, name);
       })
       .then(res => {
         expect(res.result.roles).toContain('reader');

--- a/test/userEnabled.spec.js
+++ b/test/userEnabled.spec.js
@@ -15,17 +15,17 @@ describe('userEnabled()', () => {
   });
 
   it('should enable a user recently created.', () => {
-    const username = generateRandomString();
+    const name = generateRandomString();
     const password = generateRandomString();
     return user
-      .create(conn, { username, password })
+      .create(conn, { name, password })
       .then(res => {
         expect(res.status).toBe(201);
-        return user.enable(conn, username, true);
+        return user.enable(conn, name, true);
       })
       .then(res => {
         expect(res.status).toBe(200);
-        return user.enabled(conn, username);
+        return user.enabled(conn, name);
       })
       .then(res => {
         expect(res.status).toBe(200);


### PR DESCRIPTION
Closes #70

Pass in name when creating both a user and a role.