### PR TITLE
Headers

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -68,7 +68,7 @@ const getOptions = (conn, database, params) => {
     .then(res => {
       if (res.status === 200) {
         return Object.assign({}, res, {
-          result: flat.unflatten(res.result),
+          body: flat.unflatten(res.body),
         });
       }
       return res;
@@ -167,12 +167,12 @@ const clear = (conn, database, transactionId, params = {}) => {
 const namespaces = (conn, database, params) =>
   getOptions(conn, database, params).then(res => {
     if (res.status === 200) {
-      const n = lodashGet(res, 'result.database.namespaces', []);
+      const n = lodashGet(res, 'body.database.namespaces', []);
       const names = n.reduce((memo, val) => {
         const [key, value] = val.split('=');
         return Object.assign({}, memo, { [key]: value });
       }, {});
-      res.result = names;
+      res.body = names;
     }
     return res;
   });

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -40,10 +40,10 @@ const property = (conn, database, options, params) =>
     `,
     params
   ).then(res => {
-    const values = lodashGet(res, 'result.results.bindings', []);
+    const values = lodashGet(res, 'body.results.bindings', []);
     if (values.length > 0) {
       return Object.assign({}, res, {
-        result: values[0].val.value,
+        body: values[0].val.value,
       });
     }
     return res;

--- a/lib/query/utils.js
+++ b/lib/query/utils.js
@@ -18,7 +18,7 @@ const queryType = query => {
     return 'ask';
   }
 
-  if (q.startsWith('construct') || q.startsWith('graph')) {
+  if (q.startsWith('construct')) {
     return 'construct';
   }
 

--- a/lib/response-transforms.js
+++ b/lib/response-transforms.js
@@ -1,26 +1,26 @@
+const lodashPick = require('lodash/pick');
+
+const FIELDS = ['status', 'statusText', 'headers', 'ok', 'url'];
+
 module.exports = {
-  httpMessage: res => ({
-    status: res.status,
-    statusText: res.statusText,
-  }),
+  httpMessage: res => {
+    const response = lodashPick(res, FIELDS);
+    return response;
+  },
   httpBody: res => {
     {
       const contentType = res.headers.get('content-type');
+      const response = lodashPick(res, FIELDS);
       if (contentType && contentType.indexOf('json') > -1) {
-        return res.json().then(result => ({
-          result,
-          status: res.status,
-          statusText: res.statusText,
-        }));
+        return res.json().then(json => {
+          response.result = json;
+          return response;
+        });
       }
-      return res.text().then(result => {
-        const response = {
-          status: res.status,
-          statusText: res.statusText,
-          result,
-        };
+      return res.text().then(text => {
+        response.result = text;
         if (contentType === 'text/boolean') {
-          response.result = result.toLowerCase() === 'true';
+          response.result = text.toLowerCase() === 'true';
         }
         return response;
       });

--- a/lib/response-transforms.js
+++ b/lib/response-transforms.js
@@ -5,6 +5,7 @@ const FIELDS = ['status', 'statusText', 'headers', 'ok', 'url'];
 module.exports = {
   httpMessage: res => {
     const response = lodashPick(res, FIELDS);
+    response.body = null;
     return response;
   },
   httpBody: res => {
@@ -13,14 +14,14 @@ module.exports = {
       const response = lodashPick(res, FIELDS);
       if (contentType && contentType.indexOf('json') > -1) {
         return res.json().then(json => {
-          response.result = json;
+          response.body = json;
           return response;
         });
       }
       return res.text().then(text => {
-        response.result = text;
+        response.body = text;
         if (contentType === 'text/boolean') {
-          response.result = text.toLowerCase() === 'true';
+          response.body = text.toLowerCase() === 'true';
         }
         return response;
       });

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -41,7 +41,7 @@ const begin = (conn, database, params) => {
     headers,
   })
     .then(httpBody)
-    .then(res => Object.assign({}, res, { transactionId: res.result }));
+    .then(res => Object.assign({}, res, { transactionId: res.body }));
 };
 
 const query = (conn, database, transactionId, q, params) => {

--- a/package.json
+++ b/package.json
@@ -62,13 +62,12 @@
     "url": "https://github.com/stardog-union/stardog.js/issues"
   },
   "dependencies": {
-    "fetch-ponyfill": "^4.0.0",
+    "fetch-ponyfill": "^4.1.0",
     "flat": "^2.0.1",
     "form-data": "^2.2.0",
     "isomorphic-base64": "^1.0.2",
     "lodash": "^4.17.4",
-    "querystring": "^0.2.0",
-    "restler": "~3.2.2"
+    "querystring": "^0.2.0"
   },
   "devDependencies": {
     "@types/jest": "^20.0.2",

--- a/test/changePwd.spec.js
+++ b/test/changePwd.spec.js
@@ -51,7 +51,7 @@ describe('changePwd()', () => {
       })
       .then(res => {
         expect(res.status).toEqual(200);
-        expect(res.result.databases.length).toBeGreaterThan(0);
+        expect(res.body.databases.length).toBeGreaterThan(0);
       });
   });
 });

--- a/test/clearICV.spec.js
+++ b/test/clearICV.spec.js
@@ -29,7 +29,7 @@ describe('icv', () => {
       .then(() => icv.get(conn, database))
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result.includes('<http://example.org/issues#Issue>')).toBe(
+        expect(res.body.includes('<http://example.org/issues#Issue>')).toBe(
           true
         );
       })
@@ -38,7 +38,7 @@ describe('icv', () => {
       .then(() =>
         icv.get(conn, database).then(res => {
           expect(res.status).toBe(200);
-          expect(res.result.length).toBe(0);
+          expect(res.body.length).toBe(0);
         })
       ));
 });

--- a/test/convertICV.spec.js
+++ b/test/convertICV.spec.js
@@ -26,6 +26,6 @@ describe('icv', () => {
     icv
       .convert(conn, database, icvAxioms, { contentType: 'text/turtle' })
       .then(res => {
-        expect(res.result.startsWith('SELECT')).toBe(true);
+        expect(res.body.startsWith('SELECT')).toBe(true);
       }));
 });

--- a/test/copyDB.spec.js
+++ b/test/copyDB.spec.js
@@ -28,8 +28,8 @@ describe('db.copy()', () => {
       .then(res => {
         expect(res.status).toEqual(200);
         // Destination shouldn't be listed because it's not online yet and therefor didn't get copied.
-        expect(res.result.databases).not.toContain(destinationDatabase);
-        expect(res.result.databases).toContain(sourceDatabase);
+        expect(res.body.databases).not.toContain(destinationDatabase);
+        expect(res.body.databases).toContain(sourceDatabase);
       }));
 
   it('should copy an offline DB', () =>
@@ -39,7 +39,7 @@ describe('db.copy()', () => {
       .then(() => db.list(conn))
       .then(res => {
         expect(res.status).toEqual(200);
-        expect(res.result.databases).toContain(destinationDatabase);
-        expect(res.result.databases).toContain(sourceDatabase);
+        expect(res.body.databases).toContain(destinationDatabase);
+        expect(res.body.databases).toContain(sourceDatabase);
       }));
 });

--- a/test/explain.spec.js
+++ b/test/explain.spec.js
@@ -22,9 +22,9 @@ describe('queryExplain()', () => {
   it('A response with the query plan should not be empty', () =>
     query
       .explain(conn, database, 'select ?s where { ?s ?p ?o } limit 10')
-      .then(({ result }) => {
-        expect(result).toContain('Slice(offset=0, limit=10)');
-        expect(result).toContain('Projection(?s)');
-        expect(result).toContain('Scan');
+      .then(({ body }) => {
+        expect(body).toContain('Slice(offset=0, limit=10)');
+        expect(body).toContain('Projection(?s)');
+        expect(body).toContain('Scan');
       }));
 });

--- a/test/exportDB.spec.js
+++ b/test/exportDB.spec.js
@@ -23,7 +23,7 @@ describe('exportDB()', () => {
   it('should return a response with content-disposition header and the attachment export file', () =>
     db.export(conn, database).then(res => {
       expect(res.status).toBe(200);
-      expect(res.result).toHaveLength(26);
+      expect(res.body).toHaveLength(26);
     }));
 
   it('should return a response with content-disposition header and the attachment export file when using graph-uri param', () =>
@@ -33,6 +33,6 @@ describe('exportDB()', () => {
       })
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result).toHaveLength(26);
+        expect(res.body).toHaveLength(26);
       }));
 });

--- a/test/getDB.spec.js
+++ b/test/getDB.spec.js
@@ -21,9 +21,9 @@ describe('getDB()', () => {
 
   it('A response of the DB info should not be empty', () =>
     db.get(conn, database).then(res => {
-      expect(res.result.length).toBe(7482);
+      expect(res.body.length).toBe(7482);
       expect(
-        res.result.includes(
+        res.body.includes(
           'overbites terminals giros podgy vagus kinkiest xix recollected'
         )
       ).toBe(true);

--- a/test/getDBOptions.spec.js
+++ b/test/getDBOptions.spec.js
@@ -27,7 +27,7 @@ describe('db.getOptions()', () => {
   it('should get the options of an DB', () =>
     db.getOptions(conn, database).then(res => {
       expect(res.status).toEqual(200);
-      expect(res.result).toMatchObject({
+      expect(res.body).toMatchObject({
         search: {
           enabled: true,
         },

--- a/test/getDBSize.spec.js
+++ b/test/getDBSize.spec.js
@@ -19,10 +19,9 @@ describe('getDBSize()', () => {
     conn = ConnectionFactory();
   });
 
-  it('A response with the size of the DB should not be empty', () => {
+  it('A response with the size of the DB should not be empty', () =>
     db.size(conn, database).then(res => {
-      const sizeNum = parseInt(res.result, 10);
+      const sizeNum = parseInt(res.body, 10);
       expect(sizeNum).toBe(82);
-    });
-  });
+    }));
 });

--- a/test/getICV.spec.js
+++ b/test/getICV.spec.js
@@ -25,7 +25,7 @@ describe('icv', () => {
   it('should return an empty string if no constraint axioms stored', () => {
     icv.get(conn, database).then(res => {
       expect(res.status).toBe(200);
-      expect(res.result.length).toBe(0);
+      expect(res.body.length).toBe(0);
     });
   });
 
@@ -36,8 +36,8 @@ describe('icv', () => {
       .then(() => icv.get(conn, database))
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result.length).toBeGreaterThan(0);
-        expect(res.result.includes('<http://example.org/issues#Issue>')).toBe(
+        expect(res.body.length).toBeGreaterThan(0);
+        expect(res.body.includes('<http://example.org/issues#Issue>')).toBe(
           true
         );
       }));

--- a/test/getNamespaces.spec.js
+++ b/test/getNamespaces.spec.js
@@ -22,7 +22,7 @@ describe('getNamespaces()', () => {
   it('should retrieve the namespace prefix bindings for the database', () =>
     db.namespaces(conn, database).then(res => {
       expect(res.status).toEqual(200);
-      expect(res.result).toEqual({
+      expect(res.body).toEqual({
         '': 'http://example.org/issues#',
         owl: 'http://www.w3.org/2002/07/owl#',
         foaf: 'http://xmlns.com/foaf/0.1/',

--- a/test/getProperty.spec.js
+++ b/test/getProperty.spec.js
@@ -27,7 +27,7 @@ describe('query.property()', () => {
         property: '<http://localhost/vocabulary/bench/cdrom>',
       })
       .then(res => {
-        expect(res.result).toEqual(
+        expect(res.body).toEqual(
           'http://www.hogfishes.tld/richer/succories.html'
         );
       }));

--- a/test/isSuperUser.spec.js
+++ b/test/isSuperUser.spec.js
@@ -17,7 +17,7 @@ describe('isSuperUser()', () => {
 
   it("should return the value with the user's superuser flag (true)", () =>
     user.superUser(conn, 'admin').then(res => {
-      expect(res.result.superuser).toBe(true);
+      expect(res.body.superuser).toBe(true);
     }));
 
   it("should return the value with the user's superuser flag (false)", () => {
@@ -35,7 +35,7 @@ describe('isSuperUser()', () => {
         return user.superUser(conn, name);
       })
       .then(res => {
-        expect(res.result.superuser).toBe(false);
+        expect(res.body.superuser).toBe(false);
       });
   });
 });

--- a/test/isUserEnabled.spec.js
+++ b/test/isUserEnabled.spec.js
@@ -17,7 +17,7 @@ describe('user.enabled()', () => {
 
   it("should return the value with the user's enabled flag", () =>
     user.enabled(conn, 'admin').then(res => {
-      expect(res.result.enabled).toEqual(true);
+      expect(res.body.enabled).toEqual(true);
     }));
 
   it("should return the value with the user's superuser flag (false)", () => {
@@ -35,7 +35,7 @@ describe('user.enabled()', () => {
       })
       .then(() => user.enabled(conn, name))
       .then(res => {
-        expect(res.result.enabled).toEqual(false);
+        expect(res.body.enabled).toEqual(false);
       });
   });
 });

--- a/test/listDBs.spec.js
+++ b/test/listDBs.spec.js
@@ -24,7 +24,7 @@ describe('listDBs()', () => {
 
   it('should list available databases', () => {
     db.list(conn).then(res => {
-      expect(res.result.databases).toEqual(expect.arrayContaining([one, two]));
+      expect(res.body.databases).toEqual(expect.arrayContaining([one, two]));
     });
   });
 });

--- a/test/listRolePermissions.spec.js
+++ b/test/listRolePermissions.spec.js
@@ -46,9 +46,9 @@ describe('listRolePermissions()', () => {
       .then(res => {
         expect(res.status).toBe(200);
 
-        expect(res.result.permissions).toEqual(expect.anything());
-        expect(res.result.permissions.length).toBeGreaterThan(0);
-        expect(res.result.permissions[0].resource).toContain(database);
+        expect(res.body.permissions).toEqual(expect.anything());
+        expect(res.body.permissions.length).toBeGreaterThan(0);
+        expect(res.body.permissions[0].resource).toContain(database);
       });
   });
 });

--- a/test/listRoleUsers.spec.js
+++ b/test/listRoleUsers.spec.js
@@ -28,7 +28,7 @@ describe('listRoleUsers()', () => {
       .then(() => role.usersWithRole(conn, rolename))
       .then(res => {
         expect(res.status).toEqual(200);
-        expect(res.result.users).toContain('anonymous');
+        expect(res.body.users).toContain('anonymous');
       });
   });
 });

--- a/test/listRoles.spec.js
+++ b/test/listRoles.spec.js
@@ -17,7 +17,7 @@ describe('listRoles()', () => {
       .then(() => role.list(conn))
       .then(res => {
         expect(res.status).toEqual(200);
-        expect(res.result.roles).toContain('reader', rolename);
+        expect(res.body.roles).toContain('reader', rolename);
       });
   });
 });

--- a/test/listUserEffPermissions.spec.js
+++ b/test/listUserEffPermissions.spec.js
@@ -42,8 +42,8 @@ describe('listUserEffPermissions()', () => {
       .then(() => user.assignPermission(conn, name, permission))
       .then(() => user.effectivePermissions(conn, name))
       .then(res => {
-        expect(res.result.permissions.length).toBeGreaterThan(0);
-        expect(res.result.permissions).toContainEqual({
+        expect(res.body.permissions.length).toBeGreaterThan(0);
+        expect(res.body.permissions).toContainEqual({
           action: 'WRITE',
           resource: [database],
           resource_type: 'db',

--- a/test/listUserPermissions.spec.js
+++ b/test/listUserPermissions.spec.js
@@ -43,7 +43,7 @@ describe('listUserPermissions()', () => {
       .then(() => user.permissions(conn, name))
       .then(res => {
         expect(res.status).toBe(200);
-        const resources = res.result.permissions.reduce(
+        const resources = res.body.permissions.reduce(
           (memo, perm) => memo.concat(perm.resource),
           []
         );

--- a/test/listUserRoles.spec.js
+++ b/test/listUserRoles.spec.js
@@ -25,7 +25,7 @@ describe('listUserRoles()', () => {
       .then(() => user.listRoles(conn, 'anonymous'))
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result.roles).toContain(r);
+        expect(res.body.roles).toContain(r);
       });
   });
 });

--- a/test/listUsers.spec.js
+++ b/test/listUsers.spec.js
@@ -13,6 +13,6 @@ describe('List Users Test Suite', () => {
   it('should return a list of current registered users in the system.', () =>
     user.list(conn).then(res => {
       expect(res.status).toEqual(200);
-      expect(res.result.users).toContain('admin');
+      expect(res.body.users).toContain('admin');
     }));
 });

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -21,7 +21,7 @@ describe('query.execute()', () => {
     execute('select distinct ?s where { ?s ?p ?o }', {
       reasoning: true,
     }).then(res => {
-      expect(res.result.results.bindings).toHaveLength(23);
+      expect(res.body.results.bindings).toHaveLength(23);
     }));
 
   it('A query result should work with property paths', () =>
@@ -36,14 +36,14 @@ describe('query.execute()', () => {
         reasoning: true,
       }
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(6);
+      expect(res.body.results.bindings).toHaveLength(6);
     }));
 
   it('A query result should not have more bindings than its intended limit', () =>
     execute('select * where { ?s ?p ?o }', {
       limit: 10,
     }).then(res => {
-      expect(res.result.results.bindings).toHaveLength(10);
+      expect(res.body.results.bindings).toHaveLength(10);
     }));
 
   it('The baseURI option should be applied to the query', () =>
@@ -83,7 +83,7 @@ describe('query.execute()', () => {
     execute(
       'select distinct * where { ?s a <http://localhost/vocabulary/bench/Article> }'
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(3);
+      expect(res.body.results.bindings).toHaveLength(3);
     }));
 
   it('A query to Car must have result count to 3', () =>
@@ -93,14 +93,14 @@ describe('query.execute()', () => {
         reasoning: true,
       }
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(3);
+      expect(res.body.results.bindings).toHaveLength(3);
     }));
 
   it('A query to SportsCar must have result count to 1', () =>
     execute(
       'select distinct * where { ?s a <http://example.org/vehicles/SportsCar> }'
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(1);
+      expect(res.body.results.bindings).toHaveLength(1);
     }));
 
   it('A query to Vehicles must have result count to 3', () =>
@@ -110,14 +110,14 @@ describe('query.execute()', () => {
         reasoning: true,
       }
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(3);
+      expect(res.body.results.bindings).toHaveLength(3);
     }));
 
   it('A query to SportsCar must have result count to 1', () =>
     execute(
       'select distinct * where { ?s a <http://example.org/vehicles/SportsCar> }'
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(1);
+      expect(res.body.results.bindings).toHaveLength(1);
     }));
 
   it('A query to Vehicles must have result count to 3', () =>
@@ -127,7 +127,7 @@ describe('query.execute()', () => {
         reasoning: true,
       }
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(3);
+      expect(res.body.results.bindings).toHaveLength(3);
     }));
 
   it('A query to Car must have result count to 3', () =>
@@ -137,7 +137,7 @@ describe('query.execute()', () => {
         reasoning: true,
       }
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(3);
+      expect(res.body.results.bindings).toHaveLength(3);
     }));
 
   it('A query to Vehicle must have result count to 0 w/o reasoning', () =>
@@ -147,28 +147,28 @@ describe('query.execute()', () => {
         reasoning: false,
       }
     ).then(res => {
-      expect(res.result.results.bindings).toHaveLength(0);
+      expect(res.body.results.bindings).toHaveLength(0);
     }));
 
   it('returns a true boolean for an ASK query', () =>
     execute(
       'ask {<http://myvehicledata.com/FerrariEnzo> a <http://example.org/vehicles/SportsCar>}'
     ).then(res => {
-      expect(res.result).toBe(true);
+      expect(res.body).toBe(true);
     }));
 
   it('returns a false boolean for an ASK query', () =>
     execute(
       'ask {<http://myvehicledata.com/FerrariEnzo> a <http://example.org/vehicles/Sedan>}'
     ).then(res => {
-      expect(res.result).toBe(false);
+      expect(res.body).toBe(false);
     }));
 
   it('returns results for a construct query', () =>
-    execute('construct where { ?s ?p ?o }').then(({ result }) => {
-      expect(result).toHaveLength(26); // three articles defined in nodeDB
-      for (let i = 0; i < result.length; i += 1) {
-        expect(result[i]['@id'].startsWith('http://')).toBe(true);
+    execute('construct where { ?s ?p ?o }').then(({ body }) => {
+      expect(body).toHaveLength(26);
+      for (let i = 0; i < body.length; i += 1) {
+        expect(body[i]['@id'].startsWith('http://')).toBe(true);
       }
     }));
 
@@ -183,8 +183,8 @@ describe('query.execute()', () => {
             limit: 1,
           }
         )
-        .then(({ result }) => {
-          expect(result).toContain(
+        .then(({ body }) => {
+          expect(body).toContain(
             '<http://localhost/publications/articles/Journal1/1940/Article1>'
           );
         }));
@@ -201,7 +201,7 @@ describe('query.execute()', () => {
         `select ?s (Group_Concat(?o ; separator=",") as ?o_s) where { ?s <#name> ?o } group by ?s`
       ).then(res => {
         expect(res.status).toBe(200);
-        expect(res.result.results.bindings).toHaveLength(1);
+        expect(res.body.results.bindings).toHaveLength(1);
       }));
   });
 });

--- a/test/queryInfo.spec.js
+++ b/test/queryInfo.spec.js
@@ -13,7 +13,7 @@ describe('queryGet()', () => {
   it('should return 404 trying to get a queryInfo of a non-existent queryId', () => {
     const queryId = '1';
     query.get(conn, queryId).then(res => {
-      expect(res.result.message).toEqual(`Query not found: ${queryId}`);
+      expect(res.body.message).toEqual(`Query not found: ${queryId}`);
       expect(res.status).toEqual(404);
     });
   });

--- a/test/queryList.spec.js
+++ b/test/queryList.spec.js
@@ -13,7 +13,7 @@ describe('queryList()', () => {
   it.skip('should return the number of global running queries', () =>
     query.list(conn).then(res => {
       expect(res.status).toEqual(200);
-      expect(res.result.queries).toHaveLength(0);
+      expect(res.body.queries).toHaveLength(0);
     })
   );
 });

--- a/test/setUserRoles.spec.js
+++ b/test/setUserRoles.spec.js
@@ -29,7 +29,7 @@ describe('Set User Roles Test Suite', () => {
         return user.listRoles(conn, name);
       })
       .then(res => {
-        expect(res.result.roles).toContain('reader');
+        expect(res.body.roles).toContain('reader');
       });
   });
 });

--- a/test/transactions.spec.js
+++ b/test/transactions.spec.js
@@ -44,19 +44,19 @@ describe('transactions', () => {
     begin()
       .then(res => {
         expect(res.status).toEqual(200);
-        expect(res.result).toBe(res.transactionId);
-        expect(res.result).toBeGUID();
+        expect(res.body).toBe(res.transactionId);
+        expect(res.body).toBeGUID();
         return transaction.query(
           conn,
           database,
-          res.result,
+          res.body,
           'select distinct ?s where { ?s ?p ?o }',
           { limit: 10 }
         );
       })
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result.results.bindings).toHaveLength(10);
+        expect(res.body.results.bindings).toHaveLength(10);
       }));
 
   it('Should be able to get a transaction, add a triple and rollback', () => {
@@ -94,7 +94,7 @@ describe('transactions', () => {
     return begin()
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result).toBeGUID();
+        expect(res.body).toBeGUID();
         return add(res.transactionId, triple, {
           contentType: 'text/turtle',
         });
@@ -117,7 +117,7 @@ describe('transactions', () => {
       })
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result).toBe(true);
+        expect(res.body).toBe(true);
         return begin();
       })
       .then(res => {
@@ -145,7 +145,7 @@ describe('transactions', () => {
     return begin()
       .then(res => {
         expect(res.status).toEqual(200);
-        expect(res.result).toBeGUID();
+        expect(res.body).toBeGUID();
         return add(res.transactionId, triple, {
           contentType: 'text/turtle',
         });
@@ -165,7 +165,7 @@ describe('transactions', () => {
       })
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result).toBe(true);
+        expect(res.body).toBe(true);
         return begin();
       })
       .then(({ transactionId }) =>
@@ -190,7 +190,7 @@ describe('transactions', () => {
     return begin()
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result).toBeGUID();
+        expect(res.body).toBeGUID();
         return db.clear(conn, database, res.transactionId);
       })
       .then(res => {
@@ -206,15 +206,15 @@ describe('transactions', () => {
       })
       .then(res => {
         expect(res.status).toBe(200);
-        const sizeNum = parseInt(res.result, 10);
+        const sizeNum = parseInt(res.body, 10);
         expect(sizeNum).toBe(0);
         return begin();
       })
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result).toBe(res.transactionId);
-        expect(res.result).toBeGUID();
-        return add(res.result, dbContent, {
+        expect(res.body).toBe(res.transactionId);
+        expect(res.body).toBeGUID();
+        return add(res.body, dbContent, {
           contentType: 'text/turtle',
         });
       })
@@ -225,7 +225,7 @@ describe('transactions', () => {
       .then(() => db.size(conn, database))
       .then(res => {
         expect(res.status).toBe(200);
-        const sizeNum = parseInt(res.result, 10);
+        const sizeNum = parseInt(res.body, 10);
         expect(sizeNum).toBe(42);
       });
   });

--- a/test/userEnabled.spec.js
+++ b/test/userEnabled.spec.js
@@ -30,7 +30,7 @@ describe('userEnabled()', () => {
       })
       .then(res => {
         expect(res.status).toBe(200);
-        expect(res.result.enabled).toBe(true);
+        expect(res.body.enabled).toBe(true);
       });
   });
 });


### PR DESCRIPTION
🎨 - Standardize on "body" for response

Renamed "response.result" to "response.body" to be more consistent and
so you don't have to do "response.result.results" for queries.

✨ - More response values

Closes #82.

Attach more information to the response. The response objects now include
status, statusText, ok, url, and headers. The headers object is a bit of an
anomaly as it's a Map on the client, but just a regular object in Node.
It seems like version 2 of node-fetch, will properly implement the headers
object in spec, but it is still in beta.

