### PR TITLE
Cleanup typedefs

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,11 +1,30 @@
 // TypeScript Version: 2.1
 
 import Headers from 'fetch-ponyfill';
-
-declare global {
   
-  /** stardog.js: The Stardog JS API*/
-  namespace Stardog {
+declare const db: stardog.db;
+declare const query: stardog.query;
+declare const server: stardog.server;
+declare const user: stardog.user;
+
+    
+interface ConnectionOptions {
+    endpoint: string;
+    username: string;
+    password: string;
+}
+
+/** Describes the connection to a running Stardog server. */
+declare class Connection {
+    constructor(ConnectionOptions);
+
+    config(options: ConnectionOptions): void;
+    headers(): Headers;
+    uri(...resource: string[]): string;
+}
+
+/** stardog.js: The Stardog JS API*/
+declare namespace stardog {
 
     type ContentMimeTypes =
         'application/x-turtle' |
@@ -21,6 +40,31 @@ declare global {
         'application/json' |
         'text/boolean';
 
+    type Encodings =
+        'gzip' |
+        'compress' |
+        'deflate' |
+        'identity' |
+        'br';
+
+    type Action =
+        'CREATE' |
+        'DELETE' |
+        'READ' |
+        'WRITE' |
+        'GRANT' |
+        'REVOKE' |
+        'EXECUTE';
+
+    type ResourceType =
+        'db' |
+        'user' |
+        'role' |
+        'admin' |
+        'metadata' |
+        'named-graph' |
+        'icv-constraints';
+
     interface HTTPMessage {
         status: string;
         statusText: string;
@@ -31,222 +75,184 @@ declare global {
         statusText: string;
         result: Object | string | boolean | null;
     }
-    
-    interface ConnectionOptions {
-        endpoint: string;
-        username: string;
-        password: string;
+
+    interface TransactionResponse extends HTTPBody {
+        transactionId: string
     }
 
-    /** Describes the connection to a running Stardog server. */
-    class Connection {
-        constructor(ConnectionOptions);
-
-        config(options: ConnectionOptions): void;
-        headers(): Headers;
-        uri(...resource: string[]): string;
-    }
-    
-    namespace server {
-        /** Shuts down a Stardog server. */
-        function shutdown(conn: Connection, params?: Object) : Promise<HTTPMessage>;
-    }
-
-    /** Stardog database actions. */
-    namespace db {
-
-        /** Creates a new database. */
-        function create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTPMessage>;
-        /** Deletes a database. */
-        function drop(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
-        /** Gets information about a database. */
-        function get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Sets a database offline. */
-        function offline(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Sets a database online. */
-        function online(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Optimizes a database. */
-        function optimize(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
-        /** Makes a copy of a database. */
-        function copy(conn: Connection, database: string, destination: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a list of all databases on a Stardog server. */
-        function list(conn: Connection, params?: Object) : Promise<HTTPBody>;
-        /** Gets number of triples in a database. */
-        function size(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Clears the contents of a database. */
-        function clear(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a mapping of the namespaces used in a database. */
-        function namespaces(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Exports the contents of a database. */
-        function exportData(conn: Connection, database: string, options?: { mimeType: AcceptMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
-
-        /** Database options. */
-        namespace options {
-            /** Gets set of options on a database. */
-            function get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-            /** Sets options on a database. */
-            function set(conn: Connection, database: string, databaseOptions: Object, params?: Object) : Promise<HTTPMessage>;
-        }
-
-        interface TransactionResponse extends HTTPBody {
-            transactionId: string
-        }
-        interface TransactionOptions {
-            contentType: ContentMimeTypes,
-            encoding: Encodings
-        }
-        type Encodings =
-            'gzip' |
-            'compress' |
-            'deflate' |
-            'identity' |
-            'br';
-        /** Methods for managing transactions in a database. */
-        namespace transaction {
-            /** Begins a new transaction. */
-            function begin(conn: Connection, database: string, params?: Object) : Promise<TransactionResponse>;
-            /** Evaluates a SPARQL query within a transaction. */
-            function query(conn: Connection, database: string, transactionId: string, query: string, params?: Object) : Promise<TransactionResponse>;
-            /** Adds a set of statements to a transaction request. */
-            function add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
-            /** Performs a rollback in a given transaction. */
-            function rollback(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
-            /** Commits a transaction to the database, removing the transaction and making its changes permanent. */
-            function commit(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
-            /** Removes a set of statements from a transaction request. */
-            function remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
-        }
-
-        /** Methods for managing integrity constraints in a database. */
-        namespace icv {
-            /** Gets the set of integrity constraints on a given database. */
-            function get(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPBody>;
-            /** Sets a new set of integrity constraints on a given database. */
-            function set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: ContentMimeTypes }, params?: Object) : Promise<HTTPMessage>;
-            /** Removes all integrity constraints from a given database. */
-            function clear(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPMessage>;
-            /** Converts a set of integrity constraints into an equivalent SPARQL query for a given database. */
-            function convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: ContentMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
-        }
+    interface TransactionOptions {
+        contentType: ContentMimeTypes,
+        encoding: Encodings
     }
 
     interface PropertyOptions {
         uri: string,
         property: string
     }
-    /** Query actions to perform on a database. */
-    namespace query {
-        /** Gets the values for a specific property of a URI individual. */
-        function property(conn: Connection, database: string, config: PropertyOptions, params?: Object) : Promise<HTTPBody>;
-        /** Gets the query plan generated by Stardog for a given SPARQL query. */
-        function explain(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>
-        /** Executes a query against a database. */
-        function execute(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a list of actively running queries. */
-        function list(conn: Connection) : Promise<HTTPBody>;
-        /** Kills an actively running query. */
-        function kill(conn: Connection, queryId: string) : Promise<HTTPMessage>;
-        /** Gets information about an actively running query. */
-        function get(conn: Connection, queryId: string) : Promise<HTTPBody>;
 
-        interface StoredQueryOptions {
-            name: string,
-            database: string,
-            query: string,
-            /** Defaults to false. */
-            shared: boolean
+    interface StoredQueryOptions {
+        name: string,
+        database: string,
+        query: string,
+        /** Defaults to false. */
+        shared: boolean
+    }
+
+    interface User {
+        username: string;
+        password: string;
+        superuser?: boolean;
+    }
+
+    interface Role {
+        rolename: string;
+    }
+
+    interface Permission {
+        action: Action,
+        resourceType: ResourceType,
+        resources: string[],
+    }
+    
+    interface server {
+        /** Shuts down a Stardog server. */
+        shutdown(conn: Connection, params?: Object) : Promise<HTTPMessage>;
+    }
+
+    /** Stardog database actions. */
+    interface db {
+        /** Creates a new database. */
+        create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTPMessage>;
+        /** Deletes a database. */
+        drop(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
+        /** Gets information about a database. */
+        get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+        /** Sets a database offline. */
+        offline(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+        /** Sets a database online. */
+        online(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+        /** Optimizes a database. */
+        optimize(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
+        /** Makes a copy of a database. */
+        copy(conn: Connection, database: string, destination: string, params?: Object) : Promise<HTTPBody>;
+        /** Gets a list of all databases on a Stardog server. */
+        list(conn: Connection, params?: Object) : Promise<HTTPBody>;
+        /** Gets number of triples in a database. */
+        size(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+        /** Clears the contents of a database. */
+        clear(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<HTTPBody>;
+        /** Gets a mapping of the namespaces used in a database. */
+        namespaces(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+        /** Exports the contents of a database. */
+        exportData(conn: Connection, database: string, options?: { mimeType: AcceptMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
+
+        /** Database options. */
+        options: {
+            /** Gets set of options on a database. */
+            get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+            /** Sets options on a database. */
+            set(conn: Connection, database: string, databaseOptions: Object, params?: Object) : Promise<HTTPMessage>;
         }
+
+        /** Methods for managing transactions in a database. */
+        transaction: {
+            /** Begins a new transaction. */
+            begin(conn: Connection, database: string, params?: Object) : Promise<TransactionResponse>;
+            /** Evaluates a SPARQL query within a transaction. */
+            query(conn: Connection, database: string, transactionId: string, query: string, params?: Object) : Promise<TransactionResponse>;
+            /** Adds a set of statements to a transaction request. */
+            add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
+            /** Performs a rollback in a given transaction. */
+            rollback(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
+            /** Commits a transaction to the database, removing the transaction and making its changes permanent. */
+            commit(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
+            /** Removes a set of statements from a transaction request. */
+            remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
+        }
+
+        /** Methods for managing integrity constraints in a database. */
+        icv: {
+            /** Gets the set of integrity constraints on a given database. */
+            get(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPBody>;
+            /** Sets a new set of integrity constraints on a given database. */
+            set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: ContentMimeTypes }, params?: Object) : Promise<HTTPMessage>;
+            /** Removes all integrity constraints from a given database. */
+            clear(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPMessage>;
+            /** Converts a set of integrity constraints into an equivalent SPARQL query for a given database. */
+            convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: ContentMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
+        }
+    }
+
+    /** Query actions to perform on a database. */
+    interface query {
+        /** Gets the values for a specific property of a URI individual. */
+        property(conn: Connection, database: string, config: PropertyOptions, params?: Object) : Promise<HTTPBody>;
+        /** Gets the query plan generated by Stardog for a given SPARQL query. */
+        explain(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>
+        /** Executes a query against a database. */
+        execute(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>;
+        /** Gets a list of actively running queries. */
+        list(conn: Connection) : Promise<HTTPBody>;
+        /** Kills an actively running query. */
+        kill(conn: Connection, queryId: string) : Promise<HTTPMessage>;
+        /** Gets information about an actively running query. */
+        get(conn: Connection, queryId: string) : Promise<HTTPBody>;
+
         /** Manages stored queries. */
-        namespace stored {
+        stored: {
             /** Stores a query in Stardog, either on the system level or for a given database. */
-            function create(conn: Connection, config: StoredQueryOptions, params?: Object) : Promise<HTTPBody> 
+            create(conn: Connection, config: StoredQueryOptions, params?: Object) : Promise<HTTPBody> 
             /** Lists all stored queries. */
-            function list(conn: Connection, params?: Object) : Promise<HTTPBody>
+            list(conn: Connection, params?: Object) : Promise<HTTPBody>
             /** Removes a given stored query. */
-            function remove(conn: Connection, storedQuery: string, params?: Object) : Promise<HTTPBody>
+            remove(conn: Connection, storedQuery: string, params?: Object) : Promise<HTTPBody>
         }
     }
 
     /** Administrative actions for managing users, roles, and their permissions. */
-    namespace user {
-
-        interface User {
-            username: string;
-            password: string;
-            superuser?: boolean;
-        }
-
-        interface Role {
-            rolename: string;
-        }
-
-        interface Permission {
-            action: Action,
-            resourceType: ResourceType,
-            resources: string[],
-        }
-
-        type Action =
-            'CREATE' |
-            'DELETE' |
-            'READ' |
-            'WRITE' |
-            'GRANT' |
-            'REVOKE' |
-            'EXECUTE';
-
-        type ResourceType =
-            'db' |
-            'user' |
-            'role' |
-            'admin' |
-            'metadata' |
-            'named-graph' |
-            'icv-constraints';
-
+    interface user {
         /** Gets a list of users. */
-        function list(conn: Connection, params?: Object) : Promise<HTTPBody>;
+        list(conn: Connection, params?: Object) : Promise<HTTPBody>;
         /** Creates a new user. */
-        function create(conn: Connection, user: User, params?: Object) : Promise<HTTPBody>;
+        create(conn: Connection, user: User, params?: Object) : Promise<HTTPBody>;
         /** Changes a user's password. */
-        function changePassword(conn: Connection, username: string, password: string, params?: Object) : Promise<HTTPBody>;
+        changePassword(conn: Connection, username: string, password: string, params?: Object) : Promise<HTTPBody>;
         /** Verifies that a user is enabled. */
-        function enabled(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        enabled(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Enables/disables a user. */
-        function enable(conn: Connection, username: string, enabled: boolean, params?: Object) : Promise<HTTPMessage>;
+        enable(conn: Connection, username: string, enabled: boolean, params?: Object) : Promise<HTTPMessage>;
         /** Sets roles for a user. */
-        function setRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        setRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Gets a list of roles assigned to a user. */
-        function listRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        listRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Creates a new permission for a user over a given <ResourceType>. */
-        function assignPermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        assignPermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Removes a permission for a user over a given <ResourceType>. */
-        function deletePermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        deletePermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Gets a list of permissions assigned to user. */
-        function permissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        permissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Gets a list of a user's effective permissions. */
-        function effectivePermissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        effectivePermissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Verifies that a user is a superuser. */
-        function superUser(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        superUser(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         /** Deletes a user. */
-        function remove(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+        remove(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
         
-        namespace role {
+        role: {
             /** Creates a new role. */
-            function create(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
+            create(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
             /** Lists all existing roles. */
-            function list(conn: Connection, params?: Object) : Promise<HTTPBody>;
+            list(conn: Connection, params?: Object) : Promise<HTTPBody>;
             /** Deletes an existing role from the system. */
-            function remove(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
+            remove(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
             /** Lists all users that have been assigned a given role. */
-            function usersWithRole(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
+            usersWithRole(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
             /** Adds a permission over a given resource to a given role. */
-            function assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPBody>;
+            assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPBody>;
             /** Removes a permission over a given resource from a given role. */
-            function deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPMessage>;
+            deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPMessage>;
             /** Lists all permissions assigned to a given role. */
-            function permissions(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
+            permissions(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
         }
     }
-  }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,29 +4,31 @@
 
 import Headers from 'fetch-ponyfill';
 
-type ContentMimeTypes =
-    'application/x-turtle' |
-    'text/turtle' |
-    'application/rdf+xml' |
-    'text/plain' |
-    'application/x-trig' |
-    'text/x-nquads' |
-    'application/trix';
-    
-type AcceptMimeTypes =
-    'text/plain' |
-    'application/json' |
-    'text/boolean';
+namespace HTTP {
+    export type ContentMimeTypes =
+        'application/x-turtle' |
+        'text/turtle' |
+        'application/rdf+xml' |
+        'text/plain' |
+        'application/x-trig' |
+        'text/x-nquads' |
+        'application/trix';
 
-interface HTTPMessage {
-    status: string;
-    statusText: string;
-}
+    export type AcceptMimeTypes =
+        'text/plain' |
+        'application/json' |
+        'text/boolean';
 
-interface HTTPBody {
-    status: string;
-    statusText: string;
-    result: Object | string | boolean | null;
+    export interface Message {
+        status: string;
+        statusText: string;
+    }
+
+    export interface Body {
+        status: string;
+        statusText: string;
+        result: object | string | boolean | null;
+    }
 }
 
 interface ConnectionOptions {
@@ -43,89 +45,92 @@ declare class Connection {
     headers(): Headers;
     uri(...resource: string[]): string;
 }
-    
+
+/** Stardog HTTP server actions. */
 declare namespace server {
     /** Shuts down a Stardog server. */
-    function shutdown(conn: Connection, params?: Object) : Promise<HTTPMessage>;
+    function shutdown(conn: Connection, params?: Object): Promise<HTTP.Message>;
 }
 
 /** Stardog database actions. */
 declare namespace db {
     /** Creates a new database. */
-    function create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTPMessage>;
+    function create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTP.Message>;
     /** Deletes a database. */
-    function drop(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
+    function drop(conn: Connection, database: string, params?: Object): Promise<HTTP.Message>;
     /** Gets information about a database. */
-    function get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    function get(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
     /** Sets a database offline. */
-    function offline(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    function offline(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
     /** Sets a database online. */
-    function online(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    function online(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
     /** Optimizes a database. */
-    function optimize(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
+    function optimize(conn: Connection, database: string, params?: Object): Promise<HTTP.Message>;
     /** Makes a copy of a database. */
-    function copy(conn: Connection, database: string, destination: string, params?: Object) : Promise<HTTPBody>;
+    function copy(conn: Connection, database: string, destination: string, params?: Object): Promise<HTTP.Body>;
     /** Gets a list of all databases on a Stardog server. */
-    function list(conn: Connection, params?: Object) : Promise<HTTPBody>;
+    function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
     /** Gets number of triples in a database. */
-    function size(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    function size(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
     /** Clears the contents of a database. */
-    function clear(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<HTTPBody>;
+    function clear(conn: Connection, database: string, transactionId: string, params?: Object): Promise<HTTP.Body>;
     /** Gets a mapping of the namespaces used in a database. */
-    function namespaces(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    function namespaces(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
     /** Exports the contents of a database. */
-    function exportData(conn: Connection, database: string, options?: { mimeType: AcceptMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
+    function exportData(conn: Connection, database: string, options?: { mimeType: HTTP.AcceptMimeTypes }, params?: { graphUri: string }): Promise<HTTP.Body>;
 
     /** Database options. */
-    interface options {
+    namespace options {
         /** Gets set of options on a database. */
-        get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+        function get(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
         /** Sets options on a database. */
-        set(conn: Connection, database: string, databaseOptions: Object, params?: Object) : Promise<HTTPMessage>;
+        function set(conn: Connection, database: string, databaseOptions: Object, params?: Object): Promise<HTTP.Message>;
     }
-
-    interface TransactionResponse extends HTTPBody {
-        transactionId: string
-    }
-
-    interface TransactionOptions {
-        contentType: ContentMimeTypes,
-        encoding: Encodings
-    }
-
-    type Encodings =
-        'gzip' |
-        'compress' |
-        'deflate' |
-        'identity' |
-        'br';
 
     /** Methods for managing transactions in a database. */
-    interface transaction {
+    namespace transaction {
+
+        type Encodings =
+            'gzip' |
+            'compress' |
+            'deflate' |
+            'identity' |
+            'br';
+
+        interface TransactionResponse extends HTTP.Body {
+            transactionId: string
+        }
+
+        interface TransactionOptions {
+            contentType: HTTP.ContentMimeTypes,
+            encoding: Encodings
+        }
+
+
         /** Begins a new transaction. */
-        begin(conn: Connection, database: string, params?: Object) : Promise<TransactionResponse>;
+        function begin(conn: Connection, database: string, params?: Object): Promise<TransactionResponse>;
         /** Evaluates a SPARQL query within a transaction. */
-        query(conn: Connection, database: string, transactionId: string, query: string, params?: Object) : Promise<TransactionResponse>;
+        function query(conn: Connection, database: string, transactionId: string, query: string, params?: Object): Promise<TransactionResponse>;
         /** Adds a set of statements to a transaction request. */
-        add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
+        function add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object): Promise<TransactionResponse>;
         /** Performs a rollback in a given transaction. */
-        rollback(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
+        function rollback(conn: Connection, database: string, transactionId: string, params?: Object): Promise<TransactionResponse>;
         /** Commits a transaction to the database, removing the transaction and making its changes permanent. */
-        commit(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
+        function commit(conn: Connection, database: string, transactionId: string, params?: Object): Promise<TransactionResponse>;
         /** Removes a set of statements from a transaction request. */
-        remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
+        function remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object): Promise<TransactionResponse>;
     }
 
     /** Methods for managing integrity constraints in a database. */
-    interface icv {
+    namespace icv {
         /** Gets the set of integrity constraints on a given database. */
-        get(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPBody>;
+        function get(conn: Connection, database: string, options: Object, params?: Object): Promise<HTTP.Body>;
         /** Sets a new set of integrity constraints on a given database. */
-        set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: ContentMimeTypes }, params?: Object) : Promise<HTTPMessage>;
+        function set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: HTTP.ContentMimeTypes }, params?: Object): Promise<HTTP.Message>;
         /** Removes all integrity constraints from a given database. */
-        clear(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPMessage>;
+        function clear(conn: Connection, database: string, options: Object, params?: Object): Promise<HTTP.Message>;
         /** Converts a set of integrity constraints into an equivalent SPARQL query for a given database. */
-        convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: ContentMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
+        function convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: HTTP.ContentMimeTypes }, params?: { graphUri: string }): Promise<HTTP.Body>;
     }
 }
 
@@ -138,17 +143,17 @@ declare namespace query {
     }
 
     /** Gets the values for a specific property of a URI individual. */
-    function property(conn: Connection, database: string, config: PropertyOptions, params?: Object) : Promise<HTTPBody>;
+    function property(conn: Connection, database: string, config: PropertyOptions, params?: Object): Promise<HTTP.Body>;
     /** Gets the query plan generated by Stardog for a given SPARQL query. */
-    function explain(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>
+    function explain(conn: Connection, database: string, query: string, params?: Object): Promise<HTTP.Body>
     /** Executes a query against a database. */
-    function execute(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>;
+    function execute(conn: Connection, database: string, query: string, params?: Object): Promise<HTTP.Body>;
     /** Gets a list of actively running queries. */
-    function list(conn: Connection) : Promise<HTTPBody>;
+    function list(conn: Connection): Promise<HTTP.Body>;
     /** Kills an actively running query. */
-    function kill(conn: Connection, queryId: string) : Promise<HTTPMessage>;
+    function kill(conn: Connection, queryId: string): Promise<HTTP.Message>;
     /** Gets information about an actively running query. */
-    function get(conn: Connection, queryId: string) : Promise<HTTPBody>;
+    function get(conn: Connection, queryId: string): Promise<HTTP.Body>;
 
     interface StoredQueryOptions {
         name: string,
@@ -159,13 +164,13 @@ declare namespace query {
     }
 
     /** Manages stored queries. */
-    interface stored {
+    namespace stored {
         /** Stores a query in Stardog, either on the system level or for a given database. */
-        create(conn: Connection, config: StoredQueryOptions, params?: Object) : Promise<HTTPBody> 
+        function create(conn: Connection, config: StoredQueryOptions, params?: Object): Promise<HTTP.Body>
         /** Lists all stored queries. */
-        list(conn: Connection, params?: Object) : Promise<HTTPBody>
+        function list(conn: Connection, params?: Object): Promise<HTTP.Body>
         /** Removes a given stored query. */
-        remove(conn: Connection, storedQuery: string, params?: Object) : Promise<HTTPBody>
+        function remove(conn: Connection, storedQuery: string, params?: Object): Promise<HTTP.Body>
     }
 }
 
@@ -176,43 +181,6 @@ declare namespace user {
         username: string;
         password: string;
         superuser?: boolean;
-    }
-
-    /** Gets a list of users. */
-    function list(conn: Connection, params?: Object) : Promise<HTTPBody>;
-    /** Creates a new user. */
-    function create(conn: Connection, user: User, params?: Object) : Promise<HTTPBody>;
-    /** Changes a user's password. */
-    function changePassword(conn: Connection, username: string, password: string, params?: Object) : Promise<HTTPBody>;
-    /** Verifies that a user is enabled. */
-    function enabled(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Enables/disables a user. */
-    function enable(conn: Connection, username: string, enabled: boolean, params?: Object) : Promise<HTTPMessage>;
-    /** Sets roles for a user. */
-    function setRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Gets a list of roles assigned to a user. */
-    function listRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Creates a new permission for a user over a given <ResourceType>. */
-    function assignPermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Removes a permission for a user over a given <ResourceType>. */
-    function deletePermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Gets a list of permissions assigned to user. */
-    function permissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Gets a list of a user's effective permissions. */
-    function effectivePermissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Verifies that a user is a superuser. */
-    function superUser(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    /** Deletes a user. */
-    function remove(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-    
-    interface Role {
-        rolename: string;
-    }
-    
-    interface Permission {
-        action: Action,
-        resourceType: ResourceType,
-        resources: string[],
     }
 
     type Action =
@@ -233,20 +201,57 @@ declare namespace user {
         'named-graph' |
         'icv-constraints';
 
-    interface role {
+    /** Gets a list of users. */
+    function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
+    /** Creates a new user. */
+    function create(conn: Connection, user: User, params?: Object): Promise<HTTP.Body>;
+    /** Changes a user's password. */
+    function changePassword(conn: Connection, username: string, password: string, params?: Object): Promise<HTTP.Body>;
+    /** Verifies that a user is enabled. */
+    function enabled(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Enables/disables a user. */
+    function enable(conn: Connection, username: string, enabled: boolean, params?: Object): Promise<HTTP.Message>;
+    /** Sets roles for a user. */
+    function setRoles(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Gets a list of roles assigned to a user. */
+    function listRoles(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Creates a new permission for a user over a given <ResourceType>. */
+    function assignPermission(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Removes a permission for a user over a given <ResourceType>. */
+    function deletePermission(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Gets a list of permissions assigned to user. */
+    function permissions(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Gets a list of a user's effective permissions. */
+    function effectivePermissions(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Verifies that a user is a superuser. */
+    function superUser(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+    /** Deletes a user. */
+    function remove(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+
+    interface Role {
+        rolename: string;
+    }
+
+    interface Permission {
+        action: Action,
+        resourceType: ResourceType,
+        resources: string[],
+    }
+
+    namespace role {
         /** Creates a new role. */
-        create(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
+        function create(conn: Connection, role: Role, params?: Object): Promise<HTTP.Message>;
         /** Lists all existing roles. */
-        list(conn: Connection, params?: Object) : Promise<HTTPBody>;
+        function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
         /** Deletes an existing role from the system. */
-        remove(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
+        function remove(conn: Connection, role: Role, params?: Object): Promise<HTTP.Message>;
         /** Lists all users that have been assigned a given role. */
-        usersWithRole(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
+        function usersWithRole(conn: Connection, role: Role, params?: Object): Promise<HTTP.Body>;
         /** Adds a permission over a given resource to a given role. */
-        assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPBody>;
+        function assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object): Promise<HTTP.Body>;
         /** Removes a permission over a given resource from a given role. */
-        deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPMessage>;
+        function deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object): Promise<HTTP.Message>;
         /** Lists all permissions assigned to a given role. */
-        permissions(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
+        function permissions(conn: Connection, role: Role, params?: Object): Promise<HTTP.Body>;
     }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,254 +4,262 @@
 
 import Headers from 'fetch-ponyfill';
 
-namespace HTTP {
-    export type ContentMimeTypes =
-        'application/x-turtle' |
-        'text/turtle' |
-        'application/rdf+xml' |
-        'text/plain' |
-        'application/x-trig' |
-        'text/x-nquads' |
-        'application/trix';
+declare namespace Stardog {
+    namespace HTTP {
+        export type ContentMimeTypes =
+            'application/x-turtle' |
+            'text/turtle' |
+            'application/rdf+xml' |
+            'text/plain' |
+            'application/x-trig' |
+            'text/x-nquads' |
+            'application/trix';
 
-    export type AcceptMimeTypes =
-        'text/plain' |
-        'application/json' |
-        'text/boolean';
+        export type AcceptMimeTypes =
+            'text/plain' |
+            'application/json' |
+            'text/boolean';
 
-    export interface Message {
-        status: string;
-        statusText: string;
-    }
-
-    export interface Body {
-        status: string;
-        statusText: string;
-        result: object | string | boolean | null;
-    }
-}
-
-interface ConnectionOptions {
-    endpoint: string;
-    username: string;
-    password: string;
-}
-
-/** Describes the connection to a running Stardog server. */
-declare class Connection {
-    constructor(ConnectionOptions);
-
-    config(options: ConnectionOptions): void;
-    headers(): Headers;
-    uri(...resource: string[]): string;
-}
-
-/** Stardog HTTP server actions. */
-declare namespace server {
-    /** Shuts down a Stardog server. */
-    function shutdown(conn: Connection, params?: Object): Promise<HTTP.Message>;
-}
-
-/** Stardog database actions. */
-declare namespace db {
-    /** Creates a new database. */
-    function create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTP.Message>;
-    /** Deletes a database. */
-    function drop(conn: Connection, database: string, params?: Object): Promise<HTTP.Message>;
-    /** Gets information about a database. */
-    function get(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
-    /** Sets a database offline. */
-    function offline(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
-    /** Sets a database online. */
-    function online(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
-    /** Optimizes a database. */
-    function optimize(conn: Connection, database: string, params?: Object): Promise<HTTP.Message>;
-    /** Makes a copy of a database. */
-    function copy(conn: Connection, database: string, destination: string, params?: Object): Promise<HTTP.Body>;
-    /** Gets a list of all databases on a Stardog server. */
-    function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
-    /** Gets number of triples in a database. */
-    function size(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
-    /** Clears the contents of a database. */
-    function clear(conn: Connection, database: string, transactionId: string, params?: Object): Promise<HTTP.Body>;
-    /** Gets a mapping of the namespaces used in a database. */
-    function namespaces(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
-    /** Exports the contents of a database. */
-    function exportData(conn: Connection, database: string, options?: { mimeType: HTTP.AcceptMimeTypes }, params?: { graphUri: string }): Promise<HTTP.Body>;
-
-    /** Database options. */
-    namespace options {
-        /** Gets set of options on a database. */
-        function get(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
-        /** Sets options on a database. */
-        function set(conn: Connection, database: string, databaseOptions: Object, params?: Object): Promise<HTTP.Message>;
-    }
-
-    /** Methods for managing transactions in a database. */
-    namespace transaction {
-
-        type Encodings =
-            'gzip' |
-            'compress' |
-            'deflate' |
-            'identity' |
-            'br';
-
-        interface TransactionResponse extends HTTP.Body {
-            transactionId: string
+        export interface Message {
+            status: string;
+            statusText: string;
         }
 
-        interface TransactionOptions {
-            contentType: HTTP.ContentMimeTypes,
-            encoding: Encodings
+        export interface Body {
+            status: string;
+            statusText: string;
+            result: object | string | boolean | null;
         }
-
-
-        /** Begins a new transaction. */
-        function begin(conn: Connection, database: string, params?: Object): Promise<TransactionResponse>;
-        /** Evaluates a SPARQL query within a transaction. */
-        function query(conn: Connection, database: string, transactionId: string, query: string, params?: Object): Promise<TransactionResponse>;
-        /** Adds a set of statements to a transaction request. */
-        function add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object): Promise<TransactionResponse>;
-        /** Performs a rollback in a given transaction. */
-        function rollback(conn: Connection, database: string, transactionId: string, params?: Object): Promise<TransactionResponse>;
-        /** Commits a transaction to the database, removing the transaction and making its changes permanent. */
-        function commit(conn: Connection, database: string, transactionId: string, params?: Object): Promise<TransactionResponse>;
-        /** Removes a set of statements from a transaction request. */
-        function remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object): Promise<TransactionResponse>;
     }
 
-    /** Methods for managing integrity constraints in a database. */
-    namespace icv {
-        /** Gets the set of integrity constraints on a given database. */
-        function get(conn: Connection, database: string, options: Object, params?: Object): Promise<HTTP.Body>;
-        /** Sets a new set of integrity constraints on a given database. */
-        function set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: HTTP.ContentMimeTypes }, params?: Object): Promise<HTTP.Message>;
-        /** Removes all integrity constraints from a given database. */
-        function clear(conn: Connection, database: string, options: Object, params?: Object): Promise<HTTP.Message>;
-        /** Converts a set of integrity constraints into an equivalent SPARQL query for a given database. */
-        function convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: HTTP.ContentMimeTypes }, params?: { graphUri: string }): Promise<HTTP.Body>;
-    }
-}
-
-/** Query actions to perform on a database. */
-declare namespace query {
-
-    interface PropertyOptions {
-        uri: string,
-        property: string
-    }
-
-    /** Gets the values for a specific property of a URI individual. */
-    function property(conn: Connection, database: string, config: PropertyOptions, params?: Object): Promise<HTTP.Body>;
-    /** Gets the query plan generated by Stardog for a given SPARQL query. */
-    function explain(conn: Connection, database: string, query: string, params?: Object): Promise<HTTP.Body>
-    /** Executes a query against a database. */
-    function execute(conn: Connection, database: string, query: string, params?: Object): Promise<HTTP.Body>;
-    /** Gets a list of actively running queries. */
-    function list(conn: Connection): Promise<HTTP.Body>;
-    /** Kills an actively running query. */
-    function kill(conn: Connection, queryId: string): Promise<HTTP.Message>;
-    /** Gets information about an actively running query. */
-    function get(conn: Connection, queryId: string): Promise<HTTP.Body>;
-
-    interface StoredQueryOptions {
-        name: string,
-        database: string,
-        query: string,
-        /** Defaults to false. */
-        shared: boolean
-    }
-
-    /** Manages stored queries. */
-    namespace stored {
-        /** Stores a query in Stardog, either on the system level or for a given database. */
-        function create(conn: Connection, config: StoredQueryOptions, params?: Object): Promise<HTTP.Body>
-        /** Lists all stored queries. */
-        function list(conn: Connection, params?: Object): Promise<HTTP.Body>
-        /** Removes a given stored query. */
-        function remove(conn: Connection, storedQuery: string, params?: Object): Promise<HTTP.Body>
-    }
-}
-
-/** Administrative actions for managing users, roles, and their permissions. */
-declare namespace user {
-
-    interface User {
+    interface ConnectionOptions {
+        endpoint: string;
         username: string;
         password: string;
-        superuser?: boolean;
     }
 
-    type Action =
-        'CREATE' |
-        'DELETE' |
-        'READ' |
-        'WRITE' |
-        'GRANT' |
-        'REVOKE' |
-        'EXECUTE';
+    /** Current version of stardog.js. Maps to package.json */
+    export const version: string;
 
-    type ResourceType =
-        'db' |
-        'user' |
-        'role' |
-        'admin' |
-        'metadata' |
-        'named-graph' |
-        'icv-constraints';
+    /** Describes the connection to a running Stardog server. */
+    export class Connection {
+        constructor(ConnectionOptions);
 
-    /** Gets a list of users. */
-    function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
-    /** Creates a new user. */
-    function create(conn: Connection, user: User, params?: Object): Promise<HTTP.Body>;
-    /** Changes a user's password. */
-    function changePassword(conn: Connection, username: string, password: string, params?: Object): Promise<HTTP.Body>;
-    /** Verifies that a user is enabled. */
-    function enabled(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Enables/disables a user. */
-    function enable(conn: Connection, username: string, enabled: boolean, params?: Object): Promise<HTTP.Message>;
-    /** Sets roles for a user. */
-    function setRoles(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Gets a list of roles assigned to a user. */
-    function listRoles(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Creates a new permission for a user over a given <ResourceType>. */
-    function assignPermission(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Removes a permission for a user over a given <ResourceType>. */
-    function deletePermission(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Gets a list of permissions assigned to user. */
-    function permissions(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Gets a list of a user's effective permissions. */
-    function effectivePermissions(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Verifies that a user is a superuser. */
-    function superUser(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-    /** Deletes a user. */
-    function remove(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
-
-    interface Role {
-        rolename: string;
+        config(options: ConnectionOptions): void;
+        headers(): Headers;
+        uri(...resource: string[]): string;
     }
 
-    interface Permission {
-        action: Action,
-        resourceType: ResourceType,
-        resources: string[],
+    /** Stardog HTTP server actions. */
+    export namespace server {
+        /** Shuts down a Stardog server. */
+        function shutdown(conn: Connection, params?: Object): Promise<HTTP.Message>;
     }
 
-    namespace role {
-        /** Creates a new role. */
-        function create(conn: Connection, role: Role, params?: Object): Promise<HTTP.Message>;
-        /** Lists all existing roles. */
+    /** Stardog database actions. */
+    export namespace db {
+        /** Creates a new database. */
+        function create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTP.Message>;
+        /** Deletes a database. */
+        function drop(conn: Connection, database: string, params?: Object): Promise<HTTP.Message>;
+        /** Gets information about a database. */
+        function get(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
+        /** Sets a database offline. */
+        function offline(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
+        /** Sets a database online. */
+        function online(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
+        /** Optimizes a database. */
+        function optimize(conn: Connection, database: string, params?: Object): Promise<HTTP.Message>;
+        /** Makes a copy of a database. */
+        function copy(conn: Connection, database: string, destination: string, params?: Object): Promise<HTTP.Body>;
+        /** Gets a list of all databases on a Stardog server. */
         function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
-        /** Deletes an existing role from the system. */
-        function remove(conn: Connection, role: Role, params?: Object): Promise<HTTP.Message>;
-        /** Lists all users that have been assigned a given role. */
-        function usersWithRole(conn: Connection, role: Role, params?: Object): Promise<HTTP.Body>;
-        /** Adds a permission over a given resource to a given role. */
-        function assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object): Promise<HTTP.Body>;
-        /** Removes a permission over a given resource from a given role. */
-        function deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object): Promise<HTTP.Message>;
-        /** Lists all permissions assigned to a given role. */
-        function permissions(conn: Connection, role: Role, params?: Object): Promise<HTTP.Body>;
+        /** Gets number of triples in a database. */
+        function size(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
+        /** Clears the contents of a database. */
+        function clear(conn: Connection, database: string, transactionId: string, params?: Object): Promise<HTTP.Body>;
+        /** Gets a mapping of the namespaces used in a database. */
+        function namespaces(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
+        /** Exports the contents of a database. */
+        function exportData(conn: Connection, database: string, options?: { mimeType: HTTP.AcceptMimeTypes }, params?: { graphUri: string }): Promise<HTTP.Body>;
+
+        /** Database options. */
+        namespace options {
+            /** Gets set of options on a database. */
+            function get(conn: Connection, database: string, params?: Object): Promise<HTTP.Body>;
+            /** Sets options on a database. */
+            function set(conn: Connection, database: string, databaseOptions: Object, params?: Object): Promise<HTTP.Message>;
+        }
+
+        /** Methods for managing transactions in a database. */
+        namespace transaction {
+
+            type Encodings =
+                'gzip' |
+                'compress' |
+                'deflate' |
+                'identity' |
+                'br';
+
+            interface TransactionResponse extends HTTP.Body {
+                transactionId: string
+            }
+
+            interface TransactionOptions {
+                contentType: HTTP.ContentMimeTypes,
+                encoding: Encodings
+            }
+
+
+            /** Begins a new transaction. */
+            function begin(conn: Connection, database: string, params?: Object): Promise<TransactionResponse>;
+            /** Evaluates a SPARQL query within a transaction. */
+            function query(conn: Connection, database: string, transactionId: string, query: string, params?: Object): Promise<TransactionResponse>;
+            /** Adds a set of statements to a transaction request. */
+            function add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object): Promise<TransactionResponse>;
+            /** Performs a rollback in a given transaction. */
+            function rollback(conn: Connection, database: string, transactionId: string, params?: Object): Promise<TransactionResponse>;
+            /** Commits a transaction to the database, removing the transaction and making its changes permanent. */
+            function commit(conn: Connection, database: string, transactionId: string, params?: Object): Promise<TransactionResponse>;
+            /** Removes a set of statements from a transaction request. */
+            function remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object): Promise<TransactionResponse>;
+        }
+
+        /** Methods for managing integrity constraints in a database. */
+        namespace icv {
+            /** Gets the set of integrity constraints on a given database. */
+            function get(conn: Connection, database: string, options: Object, params?: Object): Promise<HTTP.Body>;
+            /** Sets a new set of integrity constraints on a given database. */
+            function set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: HTTP.ContentMimeTypes }, params?: Object): Promise<HTTP.Message>;
+            /** Removes all integrity constraints from a given database. */
+            function clear(conn: Connection, database: string, options: Object, params?: Object): Promise<HTTP.Message>;
+            /** Converts a set of integrity constraints into an equivalent SPARQL query for a given database. */
+            function convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: HTTP.ContentMimeTypes }, params?: { graphUri: string }): Promise<HTTP.Body>;
+        }
+    }
+
+    /** Query actions to perform on a database. */
+    export namespace query {
+
+        interface PropertyOptions {
+            uri: string,
+            property: string
+        }
+
+        /** Gets the values for a specific property of a URI individual. */
+        function property(conn: Connection, database: string, config: PropertyOptions, params?: Object): Promise<HTTP.Body>;
+        /** Gets the query plan generated by Stardog for a given SPARQL query. */
+        function explain(conn: Connection, database: string, query: string, params?: Object): Promise<HTTP.Body>
+        /** Executes a query against a database. */
+        function execute(conn: Connection, database: string, query: string, params?: Object): Promise<HTTP.Body>;
+        /** Gets a list of actively running queries. */
+        function list(conn: Connection): Promise<HTTP.Body>;
+        /** Kills an actively running query. */
+        function kill(conn: Connection, queryId: string): Promise<HTTP.Message>;
+        /** Gets information about an actively running query. */
+        function get(conn: Connection, queryId: string): Promise<HTTP.Body>;
+
+        interface StoredQueryOptions {
+            name: string,
+            database: string,
+            query: string,
+            /** Defaults to false. */
+            shared: boolean
+        }
+
+        /** Manages stored queries. */
+        namespace stored {
+            /** Stores a query in Stardog, either on the system level or for a given database. */
+            function create(conn: Connection, config: StoredQueryOptions, params?: Object): Promise<HTTP.Body>
+            /** Lists all stored queries. */
+            function list(conn: Connection, params?: Object): Promise<HTTP.Body>
+            /** Removes a given stored query. */
+            function remove(conn: Connection, storedQuery: string, params?: Object): Promise<HTTP.Body>
+        }
+    }
+
+    /** Administrative actions for managing users, roles, and their permissions. */
+    export namespace user {
+
+        interface User {
+            username: string;
+            password: string;
+            superuser?: boolean;
+        }
+
+        type Action =
+            'CREATE' |
+            'DELETE' |
+            'READ' |
+            'WRITE' |
+            'GRANT' |
+            'REVOKE' |
+            'EXECUTE';
+
+        type ResourceType =
+            'db' |
+            'user' |
+            'role' |
+            'admin' |
+            'metadata' |
+            'named-graph' |
+            'icv-constraints';
+
+        /** Gets a list of users. */
+        function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
+        /** Creates a new user. */
+        function create(conn: Connection, user: User, params?: Object): Promise<HTTP.Body>;
+        /** Changes a user's password. */
+        function changePassword(conn: Connection, username: string, password: string, params?: Object): Promise<HTTP.Body>;
+        /** Verifies that a user is enabled. */
+        function enabled(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Enables/disables a user. */
+        function enable(conn: Connection, username: string, enabled: boolean, params?: Object): Promise<HTTP.Message>;
+        /** Sets roles for a user. */
+        function setRoles(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Gets a list of roles assigned to a user. */
+        function listRoles(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Creates a new permission for a user over a given <ResourceType>. */
+        function assignPermission(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Removes a permission for a user over a given <ResourceType>. */
+        function deletePermission(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Gets a list of permissions assigned to user. */
+        function permissions(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Gets a list of a user's effective permissions. */
+        function effectivePermissions(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Verifies that a user is a superuser. */
+        function superUser(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+        /** Deletes a user. */
+        function remove(conn: Connection, username: string, params?: Object): Promise<HTTP.Body>;
+
+        interface Role {
+            rolename: string;
+        }
+
+        interface Permission {
+            action: Action,
+            resourceType: ResourceType,
+            resources: string[],
+        }
+
+        namespace role {
+            /** Creates a new role. */
+            function create(conn: Connection, role: Role, params?: Object): Promise<HTTP.Message>;
+            /** Lists all existing roles. */
+            function list(conn: Connection, params?: Object): Promise<HTTP.Body>;
+            /** Deletes an existing role from the system. */
+            function remove(conn: Connection, role: Role, params?: Object): Promise<HTTP.Message>;
+            /** Lists all users that have been assigned a given role. */
+            function usersWithRole(conn: Connection, role: Role, params?: Object): Promise<HTTP.Body>;
+            /** Adds a permission over a given resource to a given role. */
+            function assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object): Promise<HTTP.Body>;
+            /** Removes a permission over a given resource from a given role. */
+            function deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object): Promise<HTTP.Message>;
+            /** Lists all permissions assigned to a given role. */
+            function permissions(conn: Connection, role: Role, params?: Object): Promise<HTTP.Body>;
+        }
     }
 }
+
+// No idea why I need this, but this is what removes the extra level of nesting
+export = Stardog;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,13 +1,34 @@
 // TypeScript Version: 2.1
 
-import Headers from 'fetch-ponyfill';
-  
-declare const db: stardog.db;
-declare const query: stardog.query;
-declare const server: stardog.server;
-declare const user: stardog.user;
+/** stardog.js: The Stardog JS API*/
 
+import Headers from 'fetch-ponyfill';
+
+type ContentMimeTypes =
+    'application/x-turtle' |
+    'text/turtle' |
+    'application/rdf+xml' |
+    'text/plain' |
+    'application/x-trig' |
+    'text/x-nquads' |
+    'application/trix';
     
+type AcceptMimeTypes =
+    'text/plain' |
+    'application/json' |
+    'text/boolean';
+
+interface HTTPMessage {
+    status: string;
+    statusText: string;
+}
+
+interface HTTPBody {
+    status: string;
+    statusText: string;
+    result: Object | string | boolean | null;
+}
+
 interface ConnectionOptions {
     endpoint: string;
     username: string;
@@ -22,23 +43,55 @@ declare class Connection {
     headers(): Headers;
     uri(...resource: string[]): string;
 }
+    
+declare namespace server {
+    /** Shuts down a Stardog server. */
+    function shutdown(conn: Connection, params?: Object) : Promise<HTTPMessage>;
+}
 
-/** stardog.js: The Stardog JS API*/
-declare namespace stardog {
+/** Stardog database actions. */
+declare namespace db {
+    /** Creates a new database. */
+    function create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTPMessage>;
+    /** Deletes a database. */
+    function drop(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
+    /** Gets information about a database. */
+    function get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    /** Sets a database offline. */
+    function offline(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    /** Sets a database online. */
+    function online(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    /** Optimizes a database. */
+    function optimize(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
+    /** Makes a copy of a database. */
+    function copy(conn: Connection, database: string, destination: string, params?: Object) : Promise<HTTPBody>;
+    /** Gets a list of all databases on a Stardog server. */
+    function list(conn: Connection, params?: Object) : Promise<HTTPBody>;
+    /** Gets number of triples in a database. */
+    function size(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    /** Clears the contents of a database. */
+    function clear(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<HTTPBody>;
+    /** Gets a mapping of the namespaces used in a database. */
+    function namespaces(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+    /** Exports the contents of a database. */
+    function exportData(conn: Connection, database: string, options?: { mimeType: AcceptMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
 
-    type ContentMimeTypes =
-        'application/x-turtle' |
-        'text/turtle' |
-        'application/rdf+xml' |
-        'text/plain' |
-        'application/x-trig' |
-        'text/x-nquads' |
-        'application/trix';
-        
-    type AcceptMimeTypes =
-        'text/plain' |
-        'application/json' |
-        'text/boolean';
+    /** Database options. */
+    interface options {
+        /** Gets set of options on a database. */
+        get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
+        /** Sets options on a database. */
+        set(conn: Connection, database: string, databaseOptions: Object, params?: Object) : Promise<HTTPMessage>;
+    }
+
+    interface TransactionResponse extends HTTPBody {
+        transactionId: string
+    }
+
+    interface TransactionOptions {
+        contentType: ContentMimeTypes,
+        encoding: Encodings
+    }
 
     type Encodings =
         'gzip' |
@@ -46,6 +99,121 @@ declare namespace stardog {
         'deflate' |
         'identity' |
         'br';
+
+    /** Methods for managing transactions in a database. */
+    interface transaction {
+        /** Begins a new transaction. */
+        begin(conn: Connection, database: string, params?: Object) : Promise<TransactionResponse>;
+        /** Evaluates a SPARQL query within a transaction. */
+        query(conn: Connection, database: string, transactionId: string, query: string, params?: Object) : Promise<TransactionResponse>;
+        /** Adds a set of statements to a transaction request. */
+        add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
+        /** Performs a rollback in a given transaction. */
+        rollback(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
+        /** Commits a transaction to the database, removing the transaction and making its changes permanent. */
+        commit(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
+        /** Removes a set of statements from a transaction request. */
+        remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
+    }
+
+    /** Methods for managing integrity constraints in a database. */
+    interface icv {
+        /** Gets the set of integrity constraints on a given database. */
+        get(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPBody>;
+        /** Sets a new set of integrity constraints on a given database. */
+        set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: ContentMimeTypes }, params?: Object) : Promise<HTTPMessage>;
+        /** Removes all integrity constraints from a given database. */
+        clear(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPMessage>;
+        /** Converts a set of integrity constraints into an equivalent SPARQL query for a given database. */
+        convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: ContentMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
+    }
+}
+
+/** Query actions to perform on a database. */
+declare namespace query {
+
+    interface PropertyOptions {
+        uri: string,
+        property: string
+    }
+
+    /** Gets the values for a specific property of a URI individual. */
+    function property(conn: Connection, database: string, config: PropertyOptions, params?: Object) : Promise<HTTPBody>;
+    /** Gets the query plan generated by Stardog for a given SPARQL query. */
+    function explain(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>
+    /** Executes a query against a database. */
+    function execute(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>;
+    /** Gets a list of actively running queries. */
+    function list(conn: Connection) : Promise<HTTPBody>;
+    /** Kills an actively running query. */
+    function kill(conn: Connection, queryId: string) : Promise<HTTPMessage>;
+    /** Gets information about an actively running query. */
+    function get(conn: Connection, queryId: string) : Promise<HTTPBody>;
+
+    interface StoredQueryOptions {
+        name: string,
+        database: string,
+        query: string,
+        /** Defaults to false. */
+        shared: boolean
+    }
+
+    /** Manages stored queries. */
+    interface stored {
+        /** Stores a query in Stardog, either on the system level or for a given database. */
+        create(conn: Connection, config: StoredQueryOptions, params?: Object) : Promise<HTTPBody> 
+        /** Lists all stored queries. */
+        list(conn: Connection, params?: Object) : Promise<HTTPBody>
+        /** Removes a given stored query. */
+        remove(conn: Connection, storedQuery: string, params?: Object) : Promise<HTTPBody>
+    }
+}
+
+/** Administrative actions for managing users, roles, and their permissions. */
+declare namespace user {
+
+    interface User {
+        username: string;
+        password: string;
+        superuser?: boolean;
+    }
+
+    /** Gets a list of users. */
+    function list(conn: Connection, params?: Object) : Promise<HTTPBody>;
+    /** Creates a new user. */
+    function create(conn: Connection, user: User, params?: Object) : Promise<HTTPBody>;
+    /** Changes a user's password. */
+    function changePassword(conn: Connection, username: string, password: string, params?: Object) : Promise<HTTPBody>;
+    /** Verifies that a user is enabled. */
+    function enabled(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Enables/disables a user. */
+    function enable(conn: Connection, username: string, enabled: boolean, params?: Object) : Promise<HTTPMessage>;
+    /** Sets roles for a user. */
+    function setRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Gets a list of roles assigned to a user. */
+    function listRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Creates a new permission for a user over a given <ResourceType>. */
+    function assignPermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Removes a permission for a user over a given <ResourceType>. */
+    function deletePermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Gets a list of permissions assigned to user. */
+    function permissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Gets a list of a user's effective permissions. */
+    function effectivePermissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Verifies that a user is a superuser. */
+    function superUser(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    /** Deletes a user. */
+    function remove(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
+    
+    interface Role {
+        rolename: string;
+    }
+    
+    interface Permission {
+        action: Action,
+        resourceType: ResourceType,
+        resources: string[],
+    }
 
     type Action =
         'CREATE' |
@@ -65,194 +233,20 @@ declare namespace stardog {
         'named-graph' |
         'icv-constraints';
 
-    interface HTTPMessage {
-        status: string;
-        statusText: string;
-    }
-
-    interface HTTPBody {
-        status: string;
-        statusText: string;
-        result: Object | string | boolean | null;
-    }
-
-    interface TransactionResponse extends HTTPBody {
-        transactionId: string
-    }
-
-    interface TransactionOptions {
-        contentType: ContentMimeTypes,
-        encoding: Encodings
-    }
-
-    interface PropertyOptions {
-        uri: string,
-        property: string
-    }
-
-    interface StoredQueryOptions {
-        name: string,
-        database: string,
-        query: string,
-        /** Defaults to false. */
-        shared: boolean
-    }
-
-    interface User {
-        username: string;
-        password: string;
-        superuser?: boolean;
-    }
-
-    interface Role {
-        rolename: string;
-    }
-
-    interface Permission {
-        action: Action,
-        resourceType: ResourceType,
-        resources: string[],
-    }
-    
-    interface server {
-        /** Shuts down a Stardog server. */
-        shutdown(conn: Connection, params?: Object) : Promise<HTTPMessage>;
-    }
-
-    /** Stardog database actions. */
-    interface db {
-        /** Creates a new database. */
-        create(conn: Connection, database: string, databaseOptions?: Object, options?: { files: string[] }, params?: Object): Promise<HTTPMessage>;
-        /** Deletes a database. */
-        drop(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
-        /** Gets information about a database. */
-        get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Sets a database offline. */
-        offline(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Sets a database online. */
-        online(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Optimizes a database. */
-        optimize(conn: Connection, database: string, params?: Object) : Promise<HTTPMessage>;
-        /** Makes a copy of a database. */
-        copy(conn: Connection, database: string, destination: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a list of all databases on a Stardog server. */
+    interface role {
+        /** Creates a new role. */
+        create(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
+        /** Lists all existing roles. */
         list(conn: Connection, params?: Object) : Promise<HTTPBody>;
-        /** Gets number of triples in a database. */
-        size(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Clears the contents of a database. */
-        clear(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a mapping of the namespaces used in a database. */
-        namespaces(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-        /** Exports the contents of a database. */
-        exportData(conn: Connection, database: string, options?: { mimeType: AcceptMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
-
-        /** Database options. */
-        options: {
-            /** Gets set of options on a database. */
-            get(conn: Connection, database: string, params?: Object) : Promise<HTTPBody>;
-            /** Sets options on a database. */
-            set(conn: Connection, database: string, databaseOptions: Object, params?: Object) : Promise<HTTPMessage>;
-        }
-
-        /** Methods for managing transactions in a database. */
-        transaction: {
-            /** Begins a new transaction. */
-            begin(conn: Connection, database: string, params?: Object) : Promise<TransactionResponse>;
-            /** Evaluates a SPARQL query within a transaction. */
-            query(conn: Connection, database: string, transactionId: string, query: string, params?: Object) : Promise<TransactionResponse>;
-            /** Adds a set of statements to a transaction request. */
-            add(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
-            /** Performs a rollback in a given transaction. */
-            rollback(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
-            /** Commits a transaction to the database, removing the transaction and making its changes permanent. */
-            commit(conn: Connection, database: string, transactionId: string, params?: Object) : Promise<TransactionResponse>;
-            /** Removes a set of statements from a transaction request. */
-            remove(conn: Connection, database: string, transactionId: string, content: string, options: TransactionOptions, params?: Object) : Promise<TransactionResponse>;
-        }
-
-        /** Methods for managing integrity constraints in a database. */
-        icv: {
-            /** Gets the set of integrity constraints on a given database. */
-            get(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPBody>;
-            /** Sets a new set of integrity constraints on a given database. */
-            set(conn: Connection, database: string, icvAxioms: string, options?: { contentType: ContentMimeTypes }, params?: Object) : Promise<HTTPMessage>;
-            /** Removes all integrity constraints from a given database. */
-            clear(conn: Connection, database: string, options: Object, params?: Object) : Promise<HTTPMessage>;
-            /** Converts a set of integrity constraints into an equivalent SPARQL query for a given database. */
-            convert(conn: Connection, database: string, icvAxioms: string, options: { contentType: ContentMimeTypes }, params?: { graphUri: string }) : Promise<HTTPBody>;
-        }
-    }
-
-    /** Query actions to perform on a database. */
-    interface query {
-        /** Gets the values for a specific property of a URI individual. */
-        property(conn: Connection, database: string, config: PropertyOptions, params?: Object) : Promise<HTTPBody>;
-        /** Gets the query plan generated by Stardog for a given SPARQL query. */
-        explain(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>
-        /** Executes a query against a database. */
-        execute(conn: Connection, database: string, query: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a list of actively running queries. */
-        list(conn: Connection) : Promise<HTTPBody>;
-        /** Kills an actively running query. */
-        kill(conn: Connection, queryId: string) : Promise<HTTPMessage>;
-        /** Gets information about an actively running query. */
-        get(conn: Connection, queryId: string) : Promise<HTTPBody>;
-
-        /** Manages stored queries. */
-        stored: {
-            /** Stores a query in Stardog, either on the system level or for a given database. */
-            create(conn: Connection, config: StoredQueryOptions, params?: Object) : Promise<HTTPBody> 
-            /** Lists all stored queries. */
-            list(conn: Connection, params?: Object) : Promise<HTTPBody>
-            /** Removes a given stored query. */
-            remove(conn: Connection, storedQuery: string, params?: Object) : Promise<HTTPBody>
-        }
-    }
-
-    /** Administrative actions for managing users, roles, and their permissions. */
-    interface user {
-        /** Gets a list of users. */
-        list(conn: Connection, params?: Object) : Promise<HTTPBody>;
-        /** Creates a new user. */
-        create(conn: Connection, user: User, params?: Object) : Promise<HTTPBody>;
-        /** Changes a user's password. */
-        changePassword(conn: Connection, username: string, password: string, params?: Object) : Promise<HTTPBody>;
-        /** Verifies that a user is enabled. */
-        enabled(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Enables/disables a user. */
-        enable(conn: Connection, username: string, enabled: boolean, params?: Object) : Promise<HTTPMessage>;
-        /** Sets roles for a user. */
-        setRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a list of roles assigned to a user. */
-        listRoles(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Creates a new permission for a user over a given <ResourceType>. */
-        assignPermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Removes a permission for a user over a given <ResourceType>. */
-        deletePermission(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a list of permissions assigned to user. */
-        permissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Gets a list of a user's effective permissions. */
-        effectivePermissions(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Verifies that a user is a superuser. */
-        superUser(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        /** Deletes a user. */
-        remove(conn: Connection, username: string, params?: Object) : Promise<HTTPBody>;
-        
-        role: {
-            /** Creates a new role. */
-            create(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
-            /** Lists all existing roles. */
-            list(conn: Connection, params?: Object) : Promise<HTTPBody>;
-            /** Deletes an existing role from the system. */
-            remove(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
-            /** Lists all users that have been assigned a given role. */
-            usersWithRole(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
-            /** Adds a permission over a given resource to a given role. */
-            assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPBody>;
-            /** Removes a permission over a given resource from a given role. */
-            deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPMessage>;
-            /** Lists all permissions assigned to a given role. */
-            permissions(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
-        }
+        /** Deletes an existing role from the system. */
+        remove(conn: Connection, role: Role, params?: Object) : Promise<HTTPMessage>;
+        /** Lists all users that have been assigned a given role. */
+        usersWithRole(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
+        /** Adds a permission over a given resource to a given role. */
+        assignPermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPBody>;
+        /** Removes a permission over a given resource from a given role. */
+        deletePermission(conn: Connection, role: Role, permission: Permission, params?: Object) : Promise<HTTPMessage>;
+        /** Lists all permissions assigned to a given role. */
+        permissions(conn: Connection, role: Role, params?: Object) : Promise<HTTPBody>;
     }
 }


### PR DESCRIPTION
Now has four top-level namespaces (`db`, `query`, `user`, `server`) and one class (`Connection`) instead of a global `stardog` namespace.