### PR TITLE
add "safe" option to the dispatchDBOptions call to the flat library

### DIFF
--- a/lib/db/options.js
+++ b/lib/db/options.js
@@ -9,7 +9,7 @@ const dispatchDBOptions = (conn, config, body) => {
   return fetch(conn.uri('admin', 'databases', config.database, 'options'), {
     method: config.method,
     headers: config.headers,
-    body: JSON.stringify(flat(body)),
+    body: JSON.stringify(flat(body, { safe: true })),
   });
 };
 


### PR DESCRIPTION
 ...to prevent arrays from being flattened when configuring DB options