### PR TITLE
Support fetch from behind proxies and/or to endpoints with self-signed certs

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1,12 +1,12 @@
-const { Headers } = require('./fetch');
+const { Headers, wrapFetch, unwrapFetch } = require('./fetch');
 const base64 = require('isomorphic-base64');
 
 class Connection {
-  constructor(options = {}) {
-    this.config(options);
+  constructor(options = {}, fetchMetadata) {
+    this.config(options, fetchMetadata);
   }
 
-  config(options) {
+  config(options, fetchMetadata) {
     const config = Object.assign({}, this, options);
 
     // If it ends with / slice it off
@@ -20,6 +20,12 @@ class Connection {
     this.endpoint = config.endpoint;
     this.username = config.username;
     this.password = config.password;
+
+    if (fetchMetadata && fetchMetadata.agent) {
+      wrapFetch(fetchMetadata);
+    } else {
+      unwrapFetch();
+    }
   }
 
   headers() {

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -6,6 +6,11 @@ class Connection {
     this.config(options, meta);
   }
 
+  // The `meta` option is useful here if the user wants to override the
+  // ordinary creation of fetch requests. Currently, the only property on
+  // `meta` that has any effect is `createRequest`, which is expected to be a
+  // function that returns either a string URL or a `Request` object that can
+  // be constructed with the supplied `Request` constructor.
   config(options, meta) {
     const config = Object.assign({}, this, options, { meta });
 
@@ -49,6 +54,9 @@ class Connection {
 
     return this.meta.createRequest({
       uri: this.uri(...resource),
+      // The Request constructor is passed here as a convenience, since it will
+      // vary based on whether this library is being used in Node-like or
+      // browser-like environments.
       Request,
     });
   }

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1,13 +1,13 @@
-const { Headers, wrapFetch, unwrapFetch } = require('./fetch');
+const { Headers, Request } = require('./fetch');
 const base64 = require('isomorphic-base64');
 
 class Connection {
-  constructor(options = {}, fetchMetadata) {
-    this.config(options, fetchMetadata);
+  constructor(options = {}, meta) {
+    this.config(options, meta);
   }
 
-  config(options, fetchMetadata) {
-    const config = Object.assign({}, this, options);
+  config(options, meta) {
+    const config = Object.assign({}, this, options, { meta });
 
     // If it ends with / slice it off
     if (
@@ -20,12 +20,7 @@ class Connection {
     this.endpoint = config.endpoint;
     this.username = config.username;
     this.password = config.password;
-
-    if (fetchMetadata && fetchMetadata.agent) {
-      wrapFetch(fetchMetadata);
-    } else {
-      unwrapFetch();
-    }
+    this.meta = config.meta;
   }
 
   headers() {
@@ -40,6 +35,22 @@ class Connection {
 
   uri(...resource) {
     return `${this.endpoint}/${resource.join('/')}`;
+  }
+
+  request(...resource) {
+    if (!this.meta || !this.meta.createRequest) {
+      // We *could* just return a new Request from this method at all times (in
+      // this case, just `new Request(this.uri(...resource))`), but,
+      // unfortunately, `new Request` throws an error in Firefox if the URI
+      // string includes credentials, which would plausibly count as a breaking
+      // change to stardog.js. Something to consider for later, though.
+      return this.uri(...resource);
+    }
+
+    return this.meta.createRequest({
+      uri: this.uri(...resource),
+      Request,
+    });
   }
 }
 

--- a/lib/db/docs.js
+++ b/lib/db/docs.js
@@ -7,14 +7,14 @@ const size = (conn, database, params = {}) => {
   const headers = conn.headers();
   headers.set('Accept', 'text/plain');
 
-  return fetch(conn.uri(database, 'docs', 'size'), {
+  return fetch(conn.request(database, 'docs', 'size'), {
     headers,
   }).then(httpBody);
 };
 
 const clear = (conn, database, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri(database, 'docs'), {
+  return fetch(conn.request(database, 'docs'), {
     method: 'DELETE',
     headers,
   }).then(httpBody);
@@ -26,7 +26,7 @@ const add = (conn, database, fileName, fileContents, params = {}) => {
   formData.append('upload', new Buffer(fileContents), {
     filename: fileName,
   });
-  return fetch(conn.uri(database, 'docs'), {
+  return fetch(conn.request(database, 'docs'), {
     method: 'POST',
     body: formData,
     headers,
@@ -35,7 +35,7 @@ const add = (conn, database, fileName, fileContents, params = {}) => {
 
 const remove = (conn, database, fileName, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri(database, 'docs', fileName), {
+  return fetch(conn.request(database, 'docs', fileName), {
     method: 'DELETE',
     headers,
   }).then(httpBody);
@@ -43,7 +43,7 @@ const remove = (conn, database, fileName, params = {}) => {
 
 const get = (conn, database, fileName, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri(database, 'docs', fileName), {
+  return fetch(conn.request(database, 'docs', fileName), {
     headers,
   }).then(httpBody);
 };

--- a/lib/db/graph.js
+++ b/lib/db/graph.js
@@ -11,22 +11,22 @@ const doGet = (
 ) => {
   const headers = conn.headers();
   headers.set('Accept', accept);
-  const uri = `${conn.uri(database)}?${graphUri
+  const resource = `${database}?${graphUri
     ? qs.stringify({ graph: graphUri })
     : 'default'}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(resource), {
     headers,
   }).then(httpBody);
 };
 
 const doDelete = (conn, database, graphUri = null, params = {}) => {
   const headers = conn.headers();
-  const uri = `${conn.uri(database)}?${graphUri
+  const resource = `${database}?${graphUri
     ? qs.stringify({ graph: graphUri })
     : 'default'}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(resource), {
     headers,
     method: 'DELETE',
   }).then(httpBody);
@@ -42,11 +42,11 @@ const doPut = (
 ) => {
   const headers = conn.headers();
   headers.set('Content-Type', contentType);
-  const uri = `${conn.uri(database)}?${graphUri
+  const resource = `${database}?${graphUri
     ? qs.stringify({ graph: graphUri })
     : 'default'}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(resource), {
     headers,
     method: 'PUT',
     body: graphData,
@@ -63,11 +63,11 @@ const doPost = (
 ) => {
   const headers = conn.headers();
   headers.set('Content-Type', contentType);
-  const uri = `${conn.uri(database)}?${graphUri
+  const resource = `${database}?${graphUri
     ? qs.stringify({ graph: graphUri })
     : 'default'}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(resource), {
     headers,
     method: 'POST',
     body: graphData,

--- a/lib/db/icv.js
+++ b/lib/db/icv.js
@@ -7,7 +7,7 @@ const get = (conn, database, params = {}) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/ld+json');
 
-  return fetch(conn.uri(database, 'icv'), {
+  return fetch(conn.request(database, 'icv'), {
     headers,
   }).then(httpBody);
 };
@@ -16,7 +16,7 @@ const add = (conn, database, icvAxioms, options = {}, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', options.contentType || 'text/turtle');
 
-  return fetch(conn.uri(database, 'icv', 'add'), {
+  return fetch(conn.request(database, 'icv', 'add'), {
     method: 'POST',
     body: icvAxioms,
     headers,
@@ -27,7 +27,7 @@ const remove = (conn, database, icvAxioms, options = {}, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', options.contentType || 'text/turtle');
 
-  return fetch(conn.uri(database, 'icv', 'remove'), {
+  return fetch(conn.request(database, 'icv', 'remove'), {
     method: 'POST',
     body: icvAxioms,
     headers,
@@ -37,7 +37,7 @@ const remove = (conn, database, icvAxioms, options = {}, params = {}) => {
 const clear = (conn, database, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri(database, 'icv', 'clear'), {
+  return fetch(conn.request(database, 'icv', 'clear'), {
     method: 'POST',
     headers,
   }).then(httpBody);
@@ -52,11 +52,9 @@ const convert = (conn, database, icvAxiom, options = {}, params = {}) => {
     queryParams['graph-uri'] = params.graphUri;
   }
   const query = qs.stringify(queryParams);
-  const uri = `${conn.uri(database, 'icv', 'convert')}${query.length > 0
-    ? `?${query}`
-    : ''}`;
+  const suffix = `convert${query.length > 0 ? `?${query}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'icv', suffix), {
     method: 'POST',
     body: icvAxiom,
     headers,
@@ -73,11 +71,9 @@ const validate = (conn, database, constraints, options = {}, params = {}) => {
     queryParams['graph-uri'] = params.graphUri;
   }
   const query = qs.stringify(queryParams);
-  const uri = `${conn.uri(database, 'icv', 'validate')}${query.length > 0
-    ? `?${query}`
-    : ''}`;
+  const suffix = `validate${query.length > 0 ? `?${query}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'icv', suffix), {
     method: 'POST',
     body: constraints,
     headers,
@@ -101,14 +97,9 @@ const validateInTx = (
     queryParams['graph-uri'] = params.graphUri;
   }
   const query = qs.stringify(queryParams);
-  const uri = `${conn.uri(
-    database,
-    'icv',
-    transactionId,
-    'validate'
-  )}${query.length > 0 ? `?${query}` : ''}`;
+  const suffix = `validate${query.length > 0 ? `?${query}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'icv', transactionId, suffix), {
     method: 'POST',
     body: constraints,
     headers,
@@ -125,11 +116,9 @@ const violations = (conn, database, constraints, options = {}, params = {}) => {
     queryParams['graph-uri'] = params.graphUri;
   }
   const query = qs.stringify(queryParams);
-  const uri = `${conn.uri(database, 'icv', 'violations')}${query.length > 0
-    ? `?${query}`
-    : ''}`;
+  const suffix = `violations${query.length > 0 ? `?${query}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'icv', suffix), {
     method: 'POST',
     body: constraints,
     headers,
@@ -153,14 +142,9 @@ const violationsInTx = (
     queryParams['graph-uri'] = params.graphUri;
   }
   const query = qs.stringify(queryParams);
-  const uri = `${conn.uri(
-    database,
-    'icv',
-    transactionId,
-    'violations'
-  )}${query.length > 0 ? `?${query}` : ''}`;
+  const suffix = `violations${query.length > 0 ? `?${query}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'icv', transactionId, suffix), {
     method: 'POST',
     body: constraints,
     headers,

--- a/lib/db/main.js
+++ b/lib/db/main.js
@@ -19,11 +19,9 @@ const dispatchChange = (conn, config, content, params = {}) => {
     queryParams['graph-uri'] = params.graphUri;
   }
   const query = qs.stringify(queryParams);
-  const uri =
-    conn.uri(config.database, config.transactionId, config.resource) +
-    (query.length > 0 ? `?${query}` : '');
+  const suffix = `${config.resource}${query.length > 0 ? `?${query}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(config.database, config.transactionId, suffix), {
     method: 'POST',
     headers,
     body: config.content + '', // eslint-disable-line prefer-template
@@ -48,7 +46,7 @@ const create = (conn, database, databaseOptions = {}, options = {}, params) => {
     })
   );
 
-  return fetch(conn.uri('admin', 'databases'), {
+  return fetch(conn.request('admin', 'databases'), {
     method: 'POST',
     headers,
     body,
@@ -57,7 +55,7 @@ const create = (conn, database, databaseOptions = {}, options = {}, params) => {
 
 const drop = (conn, database, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'databases', database), {
+  return fetch(conn.request('admin', 'databases', database), {
     method: 'DELETE',
     headers,
   }).then(httpBody);
@@ -65,7 +63,7 @@ const drop = (conn, database, params) => {
 
 const getDatabase = (conn, database, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri(database), {
+  return fetch(conn.request(database), {
     headers,
   }).then(httpBody);
 };
@@ -73,7 +71,7 @@ const getDatabase = (conn, database, params) => {
 const offline = (conn, database, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'databases', database, 'offline'), {
+  return fetch(conn.request('admin', 'databases', database, 'offline'), {
     method: 'PUT',
     headers,
   }).then(httpBody);
@@ -82,7 +80,7 @@ const offline = (conn, database, params) => {
 const online = (conn, database, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'databases', database, 'online'), {
+  return fetch(conn.request('admin', 'databases', database, 'online'), {
     method: 'PUT',
     headers,
   }).then(httpBody);
@@ -90,7 +88,7 @@ const online = (conn, database, params) => {
 
 const optimize = (conn, database, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'databases', database, 'optimize'), {
+  return fetch(conn.request('admin', 'databases', database, 'optimize'), {
     method: 'PUT',
     headers,
   }).then(httpBody);
@@ -99,13 +97,9 @@ const optimize = (conn, database, params) => {
 const copy = (conn, database, destination, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  const resource = `${conn.uri(
-    'admin',
-    'databases',
-    database,
-    'copy'
-  )}?${qs.stringify({ to: destination })}`;
-  return fetch(resource, {
+  const suffix = `copy?${qs.stringify({ to: destination })}`;
+
+  return fetch(conn.request('admin', 'databases', database, suffix), {
     method: 'PUT',
     headers,
   }).then(httpBody);
@@ -114,7 +108,7 @@ const copy = (conn, database, destination, params) => {
 const list = (conn, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'databases'), {
+  return fetch(conn.request('admin', 'databases'), {
     headers,
   }).then(httpBody);
 };
@@ -122,7 +116,7 @@ const list = (conn, params) => {
 const size = (conn, database, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'text/plain');
-  return fetch(conn.uri(database, 'size'), {
+  return fetch(conn.request(database, 'size'), {
     headers,
   }).then(httpBody);
 };
@@ -135,10 +129,9 @@ const clear = (conn, database, transactionId, params = {}) => {
     queryParams['graph-uri'] = params.graphUri;
   }
   const query = qs.stringify(queryParams);
-  const uri =
-    conn.uri(database, transactionId, 'clear') +
-    (query.length > 0 ? `?${query}` : '');
-  return fetch(uri, {
+  const suffix = `clear${query.length > 0 ? `?${query}` : ''}`;
+
+  return fetch(conn.request(database, transactionId, suffix), {
     method: 'POST',
     headers,
   })
@@ -218,9 +211,9 @@ const exportData = (conn, database, options = {}, params = {}) => {
   const queryParams = {
     'graph-uri': params.graphUri || 'tag:stardog:api:context:all',
   };
+  const suffix = `export?${qs.stringify(queryParams)}`;
 
-  const uri = `${conn.uri(database, 'export')}?${qs.stringify(queryParams)}`;
-  return fetch(uri, {
+  return fetch(conn.request(database, suffix), {
     headers,
   }).then(httpBody);
 };

--- a/lib/db/options.js
+++ b/lib/db/options.js
@@ -6,7 +6,7 @@ const { httpBody } = require('../response-transforms');
 
 const dispatchDBOptions = (conn, config, body) => {
   config.headers.set('Content-Type', 'application/json');
-  return fetch(conn.uri('admin', 'databases', config.database, 'options'), {
+  return fetch(conn.request('admin', 'databases', config.database, 'options'), {
     method: config.method,
     headers: config.headers,
     body: JSON.stringify(flat(body, { safe: true })),

--- a/lib/db/reasoning.js
+++ b/lib/db/reasoning.js
@@ -11,13 +11,11 @@ const consistency = (conn, database, options = {}, params = {}) => {
   const headers = conn.headers();
   headers.set('Accept', 'text/boolean');
 
-  const uri = `${conn.uri(
-    database,
-    'reasoning',
-    'consistency'
-  )}${options.namedGraph ? `?graph-uri=${options.namedGraph}` : ''}`;
+  const suffix = `consistency${options.namedGraph
+    ? `?graph-uri=${options.namedGraph}`
+    : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'reasoning', suffix), {
     headers,
   }).then(httpBody);
 };
@@ -28,7 +26,7 @@ const explainInference = (conn, database, inference, config, params) => {
   headers.set('Content-Type', config.contentType);
   headers.set('Accept', 'application/json');
 
-  return fetch(conn.uri(database, 'reasoning', 'explain'), {
+  return fetch(conn.request(database, 'reasoning', 'explain'), {
     method: 'POST',
     headers,
     body: inference,
@@ -40,14 +38,11 @@ const explainInference = (conn, database, inference, config, params) => {
 const explainInconsistency = (conn, database, options = {}, params = {}) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  const uri = `${conn.uri(
-    database,
-    'reasoning',
-    'explain',
-    'inconsistency'
-  )}${options.namedGraph ? `?graph-uri=${options.namedGraph}` : ''}`;
+  const suffix = `inconsistency${options.namedGraph
+    ? `?graph-uri=${options.namedGraph}`
+    : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'reasoning', 'explain', suffix), {
     method: 'POST',
     headers,
   })
@@ -69,7 +64,7 @@ const explainInferenceInTransaction = (
   if (config.encoding) {
     headers.set('Content-Encoding', config.encoding);
   }
-  return fetch(conn.uri(database, 'reasoning', transactionId, 'explain'), {
+  return fetch(conn.request(database, 'reasoning', transactionId, 'explain'), {
     method: 'POST',
     headers,
     body: inference,
@@ -84,25 +79,24 @@ const explainInconsistencyInTransaction = (
   params = {}
 ) => {
   const headers = conn.headers();
-  const uri = `${conn.uri(
-    database,
-    'reasoning',
-    transactionId,
-    'explain',
-    'inconsistency'
-  )}${options.namedGraph ? `?graph-uri=${options.namedGraph}` : ''}`;
+  const suffix = `inconsistency${options.namedGraph
+    ? `?graph-uri=${options.namedGraph}`
+    : ''}`;
 
-  return fetch(uri, {
-    method: 'POST',
-    headers,
-  }).then(httpBody);
+  return fetch(
+    conn.request(database, 'reasoning', transactionId, 'explain', suffix),
+    {
+      method: 'POST',
+      headers,
+    }
+  ).then(httpBody);
 };
 
 const schema = (conn, database, params = {}) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/ld+json');
 
-  return fetch(conn.uri(database, 'reasoning', 'schema'), {
+  return fetch(conn.request(database, 'reasoning', 'schema'), {
     headers,
   }).then(httpBody);
 };

--- a/lib/db/transaction.js
+++ b/lib/db/transaction.js
@@ -9,7 +9,7 @@ const begin = (conn, database, params = {}) => {
   const headers = conn.headers();
   headers.set('Accept', '*/*');
 
-  return fetch(conn.uri(database, 'transaction', 'begin'), {
+  return fetch(conn.request(database, 'transaction', 'begin'), {
     method: 'POST',
     headers,
   })
@@ -19,17 +19,20 @@ const begin = (conn, database, params = {}) => {
 
 const rollback = (conn, database, transactionId, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri(database, 'transaction', 'rollback', transactionId), {
-    method: 'POST',
-    headers,
-  })
+  return fetch(
+    conn.request(database, 'transaction', 'rollback', transactionId),
+    {
+      method: 'POST',
+      headers,
+    }
+  )
     .then(httpBody)
     .then(attachTransactionId(transactionId));
 };
 
 const commit = (conn, database, transactionId, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri(database, 'transaction', 'commit', transactionId), {
+  return fetch(conn.request(database, 'transaction', 'commit', transactionId), {
     method: 'POST',
     headers,
   })

--- a/lib/db/versioning.js
+++ b/lib/db/versioning.js
@@ -16,11 +16,9 @@ const executeQuery = (
 
   const queryString = qs.stringify(params);
 
-  const uri =
-    conn.uri(database, 'vcs', 'query') +
-    (queryString.length > 0 ? `?${queryString}` : '');
+  const suffix = `query${queryString.length > 0 ? `?${queryString}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, 'vcs', suffix), {
     method: 'POST',
     body: qs.stringify({ query }),
     headers,
@@ -30,7 +28,7 @@ const executeQuery = (
 const commit = (conn, database, transactionId, commitMsg, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'text/plain');
-  return fetch(conn.uri(database, 'vcs', transactionId, 'commit_msg'), {
+  return fetch(conn.request(database, 'vcs', transactionId, 'commit_msg'), {
     method: 'POST',
     body: commitMsg,
     headers,
@@ -40,7 +38,7 @@ const commit = (conn, database, transactionId, commitMsg, params = {}) => {
 const createTag = (conn, database, revisionId, tagName, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'text/plain');
-  return fetch(conn.uri(database, 'vcs', 'tags', 'create'), {
+  return fetch(conn.request(database, 'vcs', 'tags', 'create'), {
     method: 'POST',
     body: `"tag:stardog:api:versioning:version:${revisionId}", "${tagName}"`,
     headers,
@@ -50,7 +48,7 @@ const createTag = (conn, database, revisionId, tagName, params = {}) => {
 const deleteTag = (conn, database, tagName, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'text/plain');
-  return fetch(conn.uri(database, 'vcs', 'tags', 'delete'), {
+  return fetch(conn.request(database, 'vcs', 'tags', 'delete'), {
     method: 'POST',
     body: tagName,
     headers,
@@ -67,7 +65,7 @@ const revert = (
 ) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'text/plain');
-  return fetch(conn.uri(database, 'vcs', 'revert'), {
+  return fetch(conn.request(database, 'vcs', 'revert'), {
     method: 'POST',
     body: `"tag:stardog:api:versioning:version:${toRevisionId}", "tag:stardog:api:versioning:version:${fromRevisionId}", "${logMsg}"`,
     headers,

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,47 +1,8 @@
 /* eslint-disable global-require */
-const ponyfill = require('fetch-ponyfill')();
-
-const { fetch: originalFetch } = ponyfill;
+module.exports = require('fetch-ponyfill')();
 
 // Default test for using the fetch agent.
-const isNodeLike = () =>
-  Boolean(
-    global && process && /\[native code\]/.test(process.constructor.toString())
-  );
-
-const wrapFetch = fetchMetadata => {
-  ponyfill.fetch = (url, options) => {
-    const shouldUseAgent = fetchMetadata.shouldUseAgent
-      ? fetchMetadata.shouldUseAgent(url, options)
-      : isNodeLike();
-
-    if (!shouldUseAgent) {
-      return originalFetch(url, options);
-    }
-
-    // If the user passes `agent` options for a request, just use those;
-    // otherwise, use the agent on fetchMetadata
-    const adjustedOptions = options.agent
-      ? options
-      : Object.assign({}, options, {
-          agent: fetchMetadata.agent,
-        });
-
-    return originalFetch(url, adjustedOptions);
-  };
-};
-
-const unwrapFetch = () => {
-  ponyfill.fetch = originalFetch;
-};
-
-module.exports = Object.assign({}, ponyfill, {
-  // Add an extra level of indirection so that the wrapping methods above can
-  // be called (and their effects can be seen) after this module has already
-  // been imported by other modules.
-  fetch(url, options) {
-    return ponyfill.fetch(url, options);
-  },
-});
-module.exports.wrapFetch = wrapFetch;
-module.exports.unwrapFetch = unwrapFetch;
+// const isNodeLike = () =>
+//   Boolean(
+//     global && process && /\[native code\]/.test(process.constructor.toString())
+//   );

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,2 +1,47 @@
 /* eslint-disable global-require */
-module.exports = require('fetch-ponyfill')();
+const ponyfill = require('fetch-ponyfill')();
+
+const { fetch: originalFetch } = ponyfill;
+
+// Default test for using the fetch agent.
+const isNodeLike = () =>
+  Boolean(
+    global && process && /\[native code\]/.test(process.constructor.toString())
+  );
+
+const wrapFetch = fetchMetadata => {
+  ponyfill.fetch = (url, options) => {
+    const shouldUseAgent = fetchMetadata.shouldUseAgent
+      ? fetchMetadata.shouldUseAgent(url, options)
+      : isNodeLike();
+
+    if (!shouldUseAgent) {
+      return originalFetch(url, options);
+    }
+
+    // If the user passes `agent` options for a request, just use those;
+    // otherwise, use the agent on fetchMetadata
+    const adjustedOptions = options.agent
+      ? options
+      : Object.assign({}, options, {
+          agent: fetchMetadata.agent,
+        });
+
+    return originalFetch(url, adjustedOptions);
+  };
+};
+
+const unwrapFetch = () => {
+  ponyfill.fetch = originalFetch;
+};
+
+module.exports = Object.assign({}, ponyfill, {
+  // Add an extra level of indirection so that the wrapping methods above can
+  // be called (and their effects can be seen) after this module has already
+  // been imported by other modules.
+  fetch(url, options) {
+    return ponyfill.fetch(url, options);
+  },
+});
+module.exports.wrapFetch = wrapFetch;
+module.exports.unwrapFetch = unwrapFetch;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,8 +1,2 @@
 /* eslint-disable global-require */
 module.exports = require('fetch-ponyfill')();
-
-// Default test for using the fetch agent.
-// const isNodeLike = () =>
-//   Boolean(
-//     global && process && /\[native code\]/.test(process.constructor.toString())
-//   );

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,8 @@
 
 /** stardog.js: The Stardog JS API*/
 
-import Headers from 'fetch-ponyfill';
+import { Agent } from 'http';
+import { RequestInfo as NodeFetchRequestInfo, RequestInit as NodeFetchRequestInit } from 'node-fetch';
 
 declare namespace Stardog {
     namespace HTTP {
@@ -39,14 +40,19 @@ declare namespace Stardog {
         password: string;
     }
 
+    export interface FetchMetadata {
+        agent: Agent;
+        shouldUseAgent?(input: RequestInfo | NodeFetchRequestInfo, options?: RequestInit | NodeFetchRequestInit): boolean;
+    }
+
     /** Current version of stardog.js. Maps to package.json */
     export const version: string;
 
     /** Describes the connection to a running Stardog server. */
     export class Connection {
-        constructor(options: ConnectionOptions);
+        constructor(options: ConnectionOptions, fetchMetadata?: FetchMetadata);
 
-        config(options: ConnectionOptions): void;
+        config(options: ConnectionOptions, fetchMetadata?: FetchMetadata): void;
         headers(): Headers;
         uri(...resource: string[]): string;
     }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,7 +3,7 @@
 /** stardog.js: The Stardog JS API*/
 
 import { Agent } from 'http';
-import { RequestInfo as NodeFetchRequestInfo, RequestInit as NodeFetchRequestInit } from 'node-fetch';
+import { Request as NodeFetchRequest, RequestInit as NodeFetchRequestInit } from 'node-fetch';
 
 declare namespace Stardog {
     namespace HTTP {
@@ -40,9 +40,8 @@ declare namespace Stardog {
         password: string;
     }
 
-    export interface FetchMetadata {
-        agent: Agent;
-        shouldUseAgent?(input: RequestInfo | NodeFetchRequestInfo, options?: RequestInit | NodeFetchRequestInit): boolean;
+    interface ConnectionMeta {
+        createRequest?({ uri, Request, }: { uri: string; Request: { new (input: string | Request | NodeFetchRequest, init?: RequestInit | NodeFetchRequestInit): Request | NodeFetchRequest } }): string | Request | NodeFetchRequest;
     }
 
     /** Current version of stardog.js. Maps to package.json */
@@ -50,9 +49,9 @@ declare namespace Stardog {
 
     /** Describes the connection to a running Stardog server. */
     export class Connection {
-        constructor(options: ConnectionOptions, fetchMetadata?: FetchMetadata);
+        constructor(options: ConnectionOptions, meta?: ConnectionMeta);
 
-        config(options: ConnectionOptions, fetchMetadata?: FetchMetadata): void;
+        config(options: ConnectionOptions, meta?: ConnectionMeta): void;
         headers(): Headers;
         uri(...resource: string[]): string;
     }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,6 @@
 
 /** stardog.js: The Stardog JS API*/
 
-import { Agent } from 'http';
 import { Request as NodeFetchRequest, RequestInit as NodeFetchRequestInit } from 'node-fetch';
 
 declare namespace Stardog {
@@ -50,13 +49,31 @@ declare namespace Stardog {
     /** Optional meta-configuration for a Connection */
     interface ConnectionMeta {
         /**
-         * If defined, this method is called whenever a `fetch` call is about
-         * to be made for a given Connection. The method should return a
-         * `Request` object (either a browser `Request` or a `node-fetch`
-         * `Request`) or a string URI, which will be passed as the first
-         * argument to the imminent `fetch` call. This is useful in cases where
-         * fetch needs to allow connections with self-signed certificates, for
-         * example.
+         * Sometimes you might need to override stardog.js's default `fetch`
+         * behavior, which, among other things, disallows fetching via HTTPS
+         * from servers with self-signed certificates in Node. Defininig this
+         * method allows you to provide a custom Request (or URI) to stardog.js
+         * whenever a fetch call is about to occur using your Connection object
+         * (e.g., you can provide a Request object with an HTTPS agent that
+         * allows self-signed certificates). The defined method will be called
+         * with an object containing both the full URI that is about to be
+         * fetched and a constructor for Request objects (as a convenience,
+         * since the Request constructor will differ depending on whether the
+         * environment is browser-like or Node-like). You can use this URI and
+         * constructor to construct and return the thing that you would like
+         * stardog.js to pass as the first argument to the corresponding
+         * `fetch` call (either a string URI or a Request object). For example,
+         * you could return a Request object that is initialized with the
+         * same URI passed from stardog.js, but that has a custom `agent`
+         * attached:
+         *
+         * ```
+         *  {
+         *    createRequest: ({ uri, Request }) => new Request(uri, {
+         *      agent: new http.Agent(. . .),
+         *    }),
+         *  }
+         * ```
          *
          * @param {Object} requestData
          * @param {string} requestData.uri the full URI about to be fetched; includes all URI parts (protocol, hostname, path, query string, etc.)

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -40,8 +40,30 @@ declare namespace Stardog {
         password: string;
     }
 
+    // Kind of a hack, but necessary to get around the way TS libs define the `Request` object.
+    type RequestConstructor = {
+      new (input: string | Request, init?: RequestInit): Request;
+    };
+
+    type RequestCreator<Constructor = RequestConstructor, ReturnType = string | Request> = ({ uri, Request }: { uri: string; Request: Constructor }) => ReturnType;
+
+    /** Optional meta-configuration for a Connection */
     interface ConnectionMeta {
-        createRequest?({ uri, Request, }: { uri: string; Request: { new (input: string | Request | NodeFetchRequest, init?: RequestInit | NodeFetchRequestInit): Request | NodeFetchRequest } }): string | Request | NodeFetchRequest;
+        /**
+         * If defined, this method is called whenever a `fetch` call is about
+         * to be made for a given Connection. The method should return a
+         * `Request` object (either a browser `Request` or a `node-fetch`
+         * `Request`) or a string URI, which will be passed as the first
+         * argument to the imminent `fetch` call. This is useful in cases where
+         * fetch needs to allow connections with self-signed certificates, for
+         * example.
+         *
+         * @param {Object} requestData
+         * @param {string} requestData.uri the full URI about to be fetched; includes all URI parts (protocol, hostname, path, query string, etc.)
+         * @param {RequestConstructor | Class<NodeFetchRequest>} requestData.Request a request constructor, conforming either to the browser's Request spec or to `node-fetch`'s Request, depending on environment
+         * @returns {string | Request | NodeFetchRequest} a string URI or a Request object
+         */
+        createRequest?: RequestCreator<RequestConstructor | typeof NodeFetchRequest, string | (Request | NodeFetchRequest)>;
     }
 
     /** Current version of stardog.js. Maps to package.json */

--- a/lib/query/graphql.js
+++ b/lib/query/graphql.js
@@ -5,7 +5,7 @@ const { httpBody } = require('../response-transforms');
 const execute = (conn, database, query, variables = {}, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri(database, 'graphql'), {
+  return fetch(conn.request(database, 'graphql'), {
     method: 'POST',
     body: JSON.stringify({ query, variables }),
     headers,
@@ -15,7 +15,7 @@ const execute = (conn, database, query, variables = {}, params = {}) => {
 const listSchemas = (conn, database, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri(database, 'graphql', 'schemas'), {
+  return fetch(conn.request(database, 'graphql', 'schemas'), {
     headers,
   }).then(httpBody);
 };
@@ -24,7 +24,7 @@ const addSchema = (conn, database, name, schema, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'application/graphql');
 
-  return fetch(conn.uri(database, 'graphql', 'schemas', name), {
+  return fetch(conn.request(database, 'graphql', 'schemas', name), {
     method: 'PUT',
     body: schema,
     headers,
@@ -34,7 +34,7 @@ const addSchema = (conn, database, name, schema, params = {}) => {
 const getSchema = (conn, database, name, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri(database, 'graphql', 'schemas', name), {
+  return fetch(conn.request(database, 'graphql', 'schemas', name), {
     headers,
   }).then(httpBody);
 };
@@ -42,7 +42,7 @@ const getSchema = (conn, database, name, params = {}) => {
 const removeSchema = (conn, database, name, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri(database, 'graphql', 'schemas', name), {
+  return fetch(conn.request(database, 'graphql', 'schemas', name), {
     method: 'DELETE',
     headers,
   }).then(httpBody);
@@ -51,7 +51,7 @@ const removeSchema = (conn, database, name, params = {}) => {
 const clearSchemas = (conn, database, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri(database, 'graphql', 'schemas'), {
+  return fetch(conn.request(database, 'graphql', 'schemas'), {
     method: 'DELETE',
     headers,
   });

--- a/lib/query/main.js
+++ b/lib/query/main.js
@@ -12,11 +12,11 @@ const dispatchQuery = (conn, config, accept = config.accept, params = {}) => {
 
   const queryString = qs.stringify(params);
 
-  const uri =
-    conn.uri(config.database, config.resource) +
-    (queryString.length > 0 ? `?${queryString}` : '');
+  const suffix = `${config.resource}${queryString.length > 0
+    ? `?${queryString}`
+    : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(config.database, suffix), {
     method: 'POST',
     body: qs.stringify({ query: config.query }),
     headers,
@@ -63,11 +63,9 @@ const executeInTransaction = (
   headers.set('Content-Type', 'application/x-www-form-urlencoded');
   const queryString = qs.stringify(params);
 
-  const uri =
-    conn.uri(database, transactionId, 'query') +
-    (queryString.length > 0 ? `?${queryString}` : '');
+  const suffix = `query${queryString.length > 0 ? `?${queryString}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, transactionId, suffix), {
     method: 'POST',
     headers,
     body: qs.stringify({ query }),
@@ -101,11 +99,9 @@ const explain = (conn, database, query, params) => {
   headers.set('Content-Type', 'application/x-www-form-urlencoded');
 
   const queryString = qs.stringify(params);
-  const uri =
-    conn.uri(database, 'explain') +
-    (queryString.length > 0 ? `?${queryString}` : '');
+  const suffix = `explain${queryString.length > 0 ? `?${queryString}` : ''}`;
 
-  return fetch(uri, {
+  return fetch(conn.request(database, suffix), {
     method: 'POST',
     headers,
     body: qs.stringify({ query }),
@@ -116,7 +112,7 @@ const list = conn => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
 
-  return fetch(conn.uri('admin', 'queries'), {
+  return fetch(conn.request('admin', 'queries'), {
     headers,
   }).then(httpBody);
 };
@@ -124,7 +120,7 @@ const list = conn => {
 const kill = (conn, queryId) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri('admin', 'queries', queryId), {
+  return fetch(conn.request('admin', 'queries', queryId), {
     method: 'DELETE',
     headers,
   }).then(httpBody);
@@ -133,7 +129,7 @@ const kill = (conn, queryId) => {
 const get = (conn, queryId) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'queries', queryId), {
+  return fetch(conn.request('admin', 'queries', queryId), {
     headers,
   }).then(httpBody);
 };

--- a/lib/query/stored.js
+++ b/lib/query/stored.js
@@ -19,7 +19,7 @@ const create = (conn, storedQuery, params) => {
   body.creator = conn.username;
   body.shared = typeof body.shared === 'boolean' ? body.shared : false;
 
-  return fetch(conn.uri('admin', 'queries', 'stored'), {
+  return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
     method: 'POST',
     body: JSON.stringify(body),
@@ -30,7 +30,7 @@ const list = (conn, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
 
-  return fetch(conn.uri('admin', 'queries', 'stored'), {
+  return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
   }).then(httpBody);
 };
@@ -39,7 +39,7 @@ const deleteStoredQuery = (conn, storedQuery, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
 
-  return fetch(conn.uri('admin', 'queries', 'stored', storedQuery), {
+  return fetch(conn.request('admin', 'queries', 'stored', storedQuery), {
     headers,
     method: 'DELETE',
   }).then(httpBody);

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,7 @@ const { httpMessage } = require('./response-transforms');
 const shutdown = (conn, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'shutdown'), {
+  return fetch(conn.request('admin', 'shutdown'), {
     headers,
   }).then(httpMessage);
 };

--- a/lib/storedFunctions.js
+++ b/lib/storedFunctions.js
@@ -7,7 +7,7 @@ const qs = require('querystring');
 const add = (conn, functions, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri('admin', 'functions', 'stored'), {
+  return fetch(conn.request('admin', 'functions', 'stored'), {
     method: 'POST',
     body: functions,
     headers,
@@ -18,7 +18,7 @@ const get = (conn, name, params = {}) => {
   const headers = conn.headers();
 
   return fetch(
-    `${conn.uri('admin', 'functions', 'stored')}?${qs.stringify({ name })}`,
+    conn.request('admin', 'functions', `stored?${qs.stringify({ name })}`),
     {
       headers,
     }
@@ -29,7 +29,7 @@ const remove = (conn, name, params = {}) => {
   const headers = conn.headers();
 
   return fetch(
-    `${conn.uri('admin', 'functions', 'stored')}?${qs.stringify({ name })}`,
+    conn.request('admin', 'functions', `stored?${qs.stringify({ name })}`),
     {
       method: 'DELETE',
       headers,
@@ -40,7 +40,7 @@ const remove = (conn, name, params = {}) => {
 const clear = (conn, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri('admin', 'functions', 'stored'), {
+  return fetch(conn.request('admin', 'functions', 'stored'), {
     method: 'DELETE',
     headers,
   });
@@ -49,7 +49,7 @@ const clear = (conn, params = {}) => {
 const getAll = (conn, params = {}) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri('admin', 'functions', 'stored'), {
+  return fetch(conn.request('admin', 'functions', 'stored'), {
     headers,
   }).then(httpBody);
 };

--- a/lib/user/main.js
+++ b/lib/user/main.js
@@ -3,14 +3,14 @@ const { httpBody, httpMessage } = require('../response-transforms');
 
 const list = (conn, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'users'), {
+  return fetch(conn.request('admin', 'users'), {
     headers,
   }).then(httpBody);
 };
 
 const get = (conn, username, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'users', username), {
+  return fetch(conn.request('admin', 'users', username), {
     headers,
   }).then(httpBody);
 };
@@ -26,7 +26,7 @@ const create = (conn, user, params) => {
     superuser: typeof user.superuser === 'boolean' ? user.superuser : false,
   };
 
-  return fetch(conn.uri('admin', 'users'), {
+  return fetch(conn.request('admin', 'users'), {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
@@ -41,7 +41,7 @@ const changePassword = (conn, username, password, params) => {
     password,
   };
 
-  return fetch(conn.uri('admin', 'users', username, 'pwd'), {
+  return fetch(conn.request('admin', 'users', username, 'pwd'), {
     method: 'PUT',
     headers,
     body: JSON.stringify(body),
@@ -51,7 +51,7 @@ const changePassword = (conn, username, password, params) => {
 const valid = (conn, params) => {
   const headers = conn.headers();
 
-  return fetch(conn.uri('admin', 'users', 'valid'), {
+  return fetch(conn.request('admin', 'users', 'valid'), {
     headers,
   }).then(httpBody);
 };
@@ -60,7 +60,7 @@ const enabled = (conn, username, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
 
-  return fetch(conn.uri('admin', 'users', username, 'enabled'), {
+  return fetch(conn.request('admin', 'users', username, 'enabled'), {
     headers,
   }).then(httpBody);
 };
@@ -68,7 +68,7 @@ const enabled = (conn, username, params) => {
 // eslint-disable-next-line no-shadow
 const enable = (conn, username, enabled, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'users', username, 'enabled'), {
+  return fetch(conn.request('admin', 'users', username, 'enabled'), {
     method: 'PUT',
     headers,
     body: JSON.stringify({ enabled }),
@@ -78,7 +78,7 @@ const enable = (conn, username, enabled, params) => {
 const setRoles = (conn, username, roles, params) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'application/json');
-  return fetch(conn.uri('admin', 'users', username, 'roles'), {
+  return fetch(conn.request('admin', 'users', username, 'roles'), {
     method: 'PUT',
     headers,
     body: JSON.stringify({ roles }),
@@ -88,7 +88,7 @@ const setRoles = (conn, username, roles, params) => {
 const listRoles = (conn, username, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'users', username, 'roles'), {
+  return fetch(conn.request('admin', 'users', username, 'roles'), {
     headers,
   }).then(httpBody);
 };
@@ -102,7 +102,7 @@ const assignPermission = (conn, username, permission, params) => {
     resource_type: permission.resourceType,
     resource: permission.resources,
   };
-  return fetch(conn.uri('admin', 'permissions', 'user', username), {
+  return fetch(conn.request('admin', 'permissions', 'user', username), {
     method: 'PUT',
     headers,
     body: JSON.stringify(body),
@@ -117,17 +117,20 @@ const deletePermission = (conn, username, permission, params) => {
     resource_type: permission.resourceType,
     resource: permission.resources,
   };
-  return fetch(conn.uri('admin', 'permissions', 'user', username, 'delete'), {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-  }).then(httpMessage);
+  return fetch(
+    conn.request('admin', 'permissions', 'user', username, 'delete'),
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    }
+  ).then(httpMessage);
 };
 
 const permissions = (conn, username, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'permissions', 'user', username), {
+  return fetch(conn.request('admin', 'permissions', 'user', username), {
     headers,
   }).then(httpBody);
 };
@@ -136,7 +139,7 @@ const effectivePermissions = (conn, username, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
   return fetch(
-    conn.uri('admin', 'permissions', 'effective', 'user', username),
+    conn.request('admin', 'permissions', 'effective', 'user', username),
     {
       headers,
     }
@@ -147,14 +150,14 @@ const superUser = (conn, username, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
 
-  return fetch(conn.uri('admin', 'users', username, 'superuser'), {
+  return fetch(conn.request('admin', 'users', username, 'superuser'), {
     headers,
   }).then(httpBody);
 };
 
 const deleteUser = (conn, username, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'users', username), {
+  return fetch(conn.request('admin', 'users', username), {
     method: 'DELETE',
     headers,
   }).then(httpMessage);

--- a/lib/user/role.js
+++ b/lib/user/role.js
@@ -3,7 +3,7 @@ const { httpBody, httpMessage } = require('../response-transforms');
 
 const create = (conn, role, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'roles'), {
+  return fetch(conn.request('admin', 'roles'), {
     method: 'POST',
     headers,
     body: JSON.stringify({ rolename: role.name }),
@@ -13,14 +13,14 @@ const create = (conn, role, params) => {
 const list = (conn, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'roles'), {
+  return fetch(conn.request('admin', 'roles'), {
     headers,
   }).then(httpBody);
 };
 
 const deleteRole = (conn, role, params) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'roles', role), {
+  return fetch(conn.request('admin', 'roles', role), {
     method: 'DELETE',
     headers,
   }).then(httpMessage);
@@ -29,7 +29,7 @@ const deleteRole = (conn, role, params) => {
 const usersWithRole = (conn, role, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'roles', role, 'users'), {
+  return fetch(conn.request('admin', 'roles', role, 'users'), {
     headers,
   }).then(httpBody);
 };
@@ -44,7 +44,7 @@ const assignPermission = (conn, role, permission, params) => {
     resource_type: permission.resourceType,
     resource: permission.resources,
   };
-  return fetch(conn.uri('admin', 'permissions', 'role', role), {
+  return fetch(conn.request('admin', 'permissions', 'role', role), {
     method: 'PUT',
     headers,
     body: JSON.stringify(body),
@@ -59,7 +59,7 @@ const deletePermission = (conn, role, permission, params) => {
     resource_type: permission.resourceType,
     resource: permission.resources,
   };
-  return fetch(conn.uri('admin', 'permissions', 'role', role, 'delete'), {
+  return fetch(conn.request('admin', 'permissions', 'role', role, 'delete'), {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
@@ -69,7 +69,7 @@ const deletePermission = (conn, role, permission, params) => {
 const permissions = (conn, role, params) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'permissions', 'role', role), {
+  return fetch(conn.request('admin', 'permissions', 'role', role), {
     headers,
   }).then(httpBody);
 };

--- a/lib/virtualGraphs.js
+++ b/lib/virtualGraphs.js
@@ -4,7 +4,7 @@ const { httpBody } = require('./response-transforms');
 
 const list = (conn, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'virtual_graphs'), {
+  return fetch(conn.request('admin', 'virtual_graphs'), {
     headers,
   }).then(httpBody);
 };
@@ -12,7 +12,7 @@ const list = (conn, params = {}) => {
 const add = (conn, name, mappings, options, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'application/json');
-  return fetch(conn.uri('admin', 'virtual_graphs'), {
+  return fetch(conn.request('admin', 'virtual_graphs'), {
     method: 'POST',
     body: JSON.stringify({
       name,
@@ -26,7 +26,7 @@ const add = (conn, name, mappings, options, params = {}) => {
 const update = (conn, name, mappings, options, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'application/json');
-  return fetch(conn.uri('admin', 'virtual_graphs', name), {
+  return fetch(conn.request('admin', 'virtual_graphs', name), {
     method: 'PUT',
     body: JSON.stringify({
       name,
@@ -39,7 +39,7 @@ const update = (conn, name, mappings, options, params = {}) => {
 
 const remove = (conn, name, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'virtual_graphs', name), {
+  return fetch(conn.request('admin', 'virtual_graphs', name), {
     method: 'DELETE',
     headers,
   }).then(httpBody);
@@ -48,21 +48,21 @@ const remove = (conn, name, params = {}) => {
 const available = (conn, name, params = {}) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
-  return fetch(conn.uri('admin', 'virtual_graphs', name, 'available'), {
+  return fetch(conn.request('admin', 'virtual_graphs', name, 'available'), {
     headers,
   }).then(httpBody);
 };
 
 const options = (conn, name, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'virtual_graphs', name, 'options'), {
+  return fetch(conn.request('admin', 'virtual_graphs', name, 'options'), {
     headers,
   }).then(httpBody);
 };
 
 const mappings = (conn, name, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.uri('admin', 'virtual_graphs', name, 'mappings'), {
+  return fetch(conn.request('admin', 'virtual_graphs', name, 'mappings'), {
     headers,
   }).then(httpBody);
 };

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   },
   "devDependencies": {
     "@types/jest": "^20.0.2",
+    "@types/node-fetch": "^1.6.7",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-preset-es2015-rollup": "^3.0.0",
     "chalk": "^2.0.1",

--- a/test/queryList.spec.js
+++ b/test/queryList.spec.js
@@ -14,6 +14,5 @@ describe('queryList()', () => {
     query.list(conn).then(res => {
       expect(res.status).toEqual(200);
       expect(res.body.queries).toHaveLength(0);
-    })
-  );
+    }));
 });

--- a/test/reasoning.spec.js
+++ b/test/reasoning.spec.js
@@ -56,8 +56,7 @@ describe('reasoning commands', () => {
       .then(res => {
         expect(res.status).toBe(200);
         expect(res.body.proofs).toBeTruthy();
-      })
-  );
+      }));
 
   it.skip('should explain inconsistency in a tx', () =>
     beginTx()
@@ -73,8 +72,7 @@ describe('reasoning commands', () => {
       .then(res => {
         expect(res.status).toBe(200);
         expect(res.body.proofs).toBeTruthy();
-      })
-  );
+      }));
 
   it('should successfully get the schema', () =>
     reasoning.schema(conn, database).then(res => {


### PR DESCRIPTION
When a user is behind a proxy that has a self-signed certificate, or is directly hitting an HTTPS endpoint that has a self-signed certificate, `node-fetch` (used by our `fetch-ponyfill` dependency in Node-like environments) will, by default, reject the request with a "self-signed certificate" error. This prevents using stardog.js in Node/Electron under some fairly common development scenarios. The way to work around this with `node-fetch` is to supply an 'agent' for requests that allows connections with self-signed certificates (see [here](https://github.com/bitinn/node-fetch/issues/19), for example). However, `fetch-ponyfill` doesn't allow you to supply an agent. So, this PR puts a thin wrapper around the ponyfill, and allows end users to supply a custom agent to stardog.js when a connection is created (via the `fetchMetadata` parameter). Optionally, the end user can also supply a test function that tells stardog.js when to use the agent (the default test ensures that the agent is used only in Node-like environments, so that there aren't any issues when stardog.js is used in the browser). All of this is backwards-compatible and done in a way that requires as few changes as possible; if no agent is supplied, the original, unwrapped `fetch-ponyfill` is used as usual.