### PR TITLE
Allow providing "additionalHandlers" on query.execute

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -642,6 +642,10 @@ declare namespace Stardog {
             property: string
         }
 
+        interface AdditionalHandlers {
+            onResponseStart(res: Response): void;
+        }
+
         /** 
          * Gets the values for a specific property of a URI individual. 
          * 
@@ -670,8 +674,9 @@ declare namespace Stardog {
          * @param {string} query the SPARQL query to be executed
          * @param {HTTP.RdfMimeType} accept The desired HTTP MIME type of the results
          * @param {object} params additional parameters if needed
+         * @param {object} additionalHandlers additional response handlers (currently only `onResponseStart`)
          */
-        function execute(conn: Connection, database: string, query: string, accept?: HTTP.RdfMimeType, params?: object): Promise<HTTP.Body>;
+        function execute(conn: Connection, database: string, query: string, accept?: HTTP.RdfMimeType, params?: object, additionalHandlers: AdditionalHandlers): Promise<HTTP.Body>;
 
         /** 
          * Executes a query against a database within a transaction. 

--- a/lib/query/main.js
+++ b/lib/query/main.js
@@ -5,7 +5,13 @@ const qs = require('querystring');
 const { httpBody } = require('../response-transforms');
 const { mimeType, queryType } = require('./utils');
 
-const dispatchQuery = (conn, config, accept = config.accept, params = {}) => {
+const dispatchQuery = (
+  conn,
+  config,
+  accept = config.accept,
+  params = {},
+  additionalHandlers = {}
+) => {
   const headers = conn.headers();
   headers.set('Accept', accept);
   headers.set('Content-Type', 'application/x-www-form-urlencoded');
@@ -16,26 +22,33 @@ const dispatchQuery = (conn, config, accept = config.accept, params = {}) => {
     queryString.length > 0 ? `?${queryString}` : ''
   }`;
 
-  return fetch(conn.request(config.database, suffix), {
+  const fetchPromise = fetch(conn.request(config.database, suffix), {
     method: 'POST',
     body: qs.stringify({ query: config.query }),
     headers,
-  })
-    .then(httpBody)
-    .then(res => {
-      // Paths queries will return duplicate variable names
-      // in body.head.vars (#135)
-      // e.g., `paths start ?x end ?y via ?p` will return
-      // ['x', 'x', 'p', 'y', 'y']. Use of a Set here
-      // simply eliminates the duplicates for things like Studio
-      if (res.body && res.body.head && res.body.head.vars) {
-        res.body.head.vars = [...new Set(res.body.head.vars)];
-      }
-      return res;
-    });
+  });
+
+  if (additionalHandlers.onResponseStart) {
+    // Send back the response immediately when it is received if
+    // `onResponseStart` is defined. NOTE: The full results will still be
+    // returned, as well, when the promise chain below resolves.
+    fetchPromise.then(additionalHandlers.onResponseStart);
+  }
+
+  return fetchPromise.then(httpBody).then(res => {
+    // Paths queries will return duplicate variable names
+    // in body.head.vars (#135)
+    // e.g., `paths start ?x end ?y via ?p` will return
+    // ['x', 'x', 'p', 'y', 'y']. Use of a Set here
+    // simply eliminates the duplicates for things like Studio
+    if (res.body && res.body.head && res.body.head.vars) {
+      res.body.head.vars = [...new Set(res.body.head.vars)];
+    }
+    return res;
+  });
 };
 
-const execute = (conn, database, query, accept, params) => {
+const execute = (conn, database, query, accept, params, additionalHandlers) => {
   const type = queryType(query);
   return dispatchQuery(
     conn,
@@ -46,7 +59,8 @@ const execute = (conn, database, query, accept, params) => {
       resource: type === 'update' ? 'update' : 'query',
     },
     accept,
-    params
+    params,
+    additionalHandlers
   );
 };
 

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -224,6 +224,32 @@ describe('query.execute()', () => {
       }));
   });
 
+  describe('additionalHandlers', () => {
+    it('onResponseStart should be called when execute response begins', () => {
+      let responseCompleted = false;
+
+      execute(`select distinct ?s where { ?s ?p ?o }`, undefined, undefined, {
+        onResponseStart(res) {
+          expect(res.status).toBe(200);
+          expect(responseCompleted).toBe(false);
+        },
+      }).then(() => {
+        responseCompleted = true;
+      });
+    });
+
+    it('should not interfere with the full response being passed back', () => {
+      execute(`select distinct ?s where { ?s ?p ?o }`, undefined, undefined, {
+        onResponseStart(res) {
+          return res;
+        },
+      }).then(res => {
+        expect(res.status).toBe(200);
+        expect(res.body.results.bindings).toHaveLength(33);
+      });
+    });
+  });
+
   describe('paths', () => {
     const prefixes = 'prefix : <urn:paths:> ';
     it('should run a simple paths query', () =>


### PR DESCRIPTION
Adds support, tests, and typings for `additionalHandlers` (currently only `onResponseStart`) on `query.execute`.

Closes #156.