### PR TITLE
getAll and getAvailable db options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM stardog-eps-docker.jfrog.io/stardog:6.1.2
+FROM stardog-eps-docker.jfrog.io/stardog:6.2.3
 ADD ./stardog-license-key.bin /var/opt/stardog/stardog-license-key.bin
 ADD ./test/fixtures/ /var/opt/stardog/test/fixtures/

--- a/README.md
+++ b/README.md
@@ -430,6 +430,16 @@ Returns [`Promise<HTTP.Body>`](#body)
 
 ## <a name="options">options</a>
 
+#### <a name="getavailable">`db.options.getAvailable(conn)`</a>
+
+Gets all available database options with their default values. 
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+Returns [`Promise<HTTP.Body>`](#body)
+
 #### <a name="get">`db.options.get(conn, database, params)`</a>
 
 Gets set of options on a database. 
@@ -441,6 +451,18 @@ Expects the following parameters:
 - database (`string`)
 
 - params (`object`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="getall">`db.options.getAll(conn, database)`</a>
+
+Gets all options on a database. 
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- database (`string`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 

--- a/lib/db/options.js
+++ b/lib/db/options.js
@@ -6,11 +6,19 @@ const { httpBody } = require('../response-transforms');
 
 const dispatchDBOptions = (conn, config, body) => {
   config.headers.set('Content-Type', 'application/json');
-  return fetch(conn.request('admin', 'databases', config.database, 'options'), {
+
+  const requestOptions = {
     method: config.method,
     headers: config.headers,
-    body: JSON.stringify(flat(body, { safe: true })),
-  });
+  };
+
+  if (body) {
+    requestOptions.body = JSON.stringify(flat(body, { safe: true }));
+  }
+  return fetch(
+    conn.request('admin', 'databases', config.database, 'options'),
+    requestOptions
+  );
 };
 
 const get = (conn, database, params) => {
@@ -22,8 +30,28 @@ const get = (conn, database, params) => {
       database,
       method: 'PUT',
     },
-    DB_OPTIONS
+    // TODO now that `getAll` is available, remove use of DB_OPTIONS and require
+    // user to specify which options they want
+    DB_OPTIONS // the default list of options to GET values for
   )
+    .then(httpBody)
+    .then(res => {
+      if (res.status === 200) {
+        return Object.assign({}, res, {
+          body: flat.unflatten(res.body),
+        });
+      }
+      return res;
+    });
+};
+
+const getAll = (conn, database) => {
+  const headers = conn.headers();
+  return dispatchDBOptions(conn, {
+    headers,
+    database,
+    method: 'GET',
+  })
     .then(httpBody)
     .then(res => {
       if (res.status === 200) {
@@ -48,4 +76,22 @@ const set = (conn, database, databaseOptions, params) => {
   ).then(httpBody);
 };
 
-module.exports = { get, set };
+const getAvailable = conn => {
+  const headers = conn.headers();
+  headers.set('Content-Type', 'application/json');
+  return fetch(conn.request('admin', 'config_properties'), {
+    method: 'GET',
+    headers,
+  })
+    .then(httpBody)
+    .then(res => {
+      if (res.status === 200) {
+        return Object.assign({}, res, {
+          body: flat.unflatten(res.body),
+        });
+      }
+      return res;
+    });
+};
+
+module.exports = { get, getAll, set, getAvailable };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -260,8 +260,12 @@ declare namespace Stardog {
 
         /** Database options. */
         namespace options {
+            /** Gets all available database options with their default values. */
+            function getAvailable(conn: Connection): Promise<HTTP.Body>;
             /** Gets set of options on a database. */
             function get(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
+            /** Gets all options on a database. */
+            function getAll(conn: Connection, database: string): Promise<HTTP.Body>;
             /** Sets options on a database. */
             function set(conn: Connection, database: string, databaseOptions: object, params?: object): Promise<HTTP.Body>;
         }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -75,7 +75,7 @@ del('dist/*')
   .then(() => {
     console.log(
       chalk.bgBlack.greenBright(
-        'All Stardog.js builds completeled successfully.'
+        'All Stardog.js builds completed successfully.'
       )
     );
   })

--- a/test/getDBOptions.spec.js
+++ b/test/getDBOptions.spec.js
@@ -8,7 +8,7 @@ const {
   ConnectionFactory,
 } = require('./setup-database');
 
-describe('db.getOptions()', () => {
+describe('options.get()', () => {
   const database = generateDatabaseName();
   let conn;
 
@@ -24,7 +24,7 @@ describe('db.getOptions()', () => {
       expect(res.status).toEqual(404);
     }));
 
-  it('should get the options of an DB', () =>
+  it('should get the options of a DB', () =>
     options.get(conn, database).then(res => {
       expect(res.status).toEqual(200);
       expect(res.body).toMatchObject({
@@ -32,5 +32,34 @@ describe('db.getOptions()', () => {
           type: 'Disk',
         },
       });
+    }));
+});
+
+describe('options.getAll()', () => {
+  const database = generateDatabaseName();
+  let conn;
+
+  beforeAll(seedDatabase(database));
+  afterAll(dropDatabase(database));
+
+  beforeEach(() => {
+    conn = ConnectionFactory();
+  });
+  it('should get all db config properties', () =>
+    options.getAll(conn, database).then(res => {
+      expect(res.status).toEqual(200);
+      expect(typeof res.body).toEqual('object');
+    }));
+});
+
+describe('options.getAvailable', () => {
+  let conn;
+  beforeEach(() => {
+    conn = ConnectionFactory();
+  });
+  it('should get all available config properties', () =>
+    options.getAvailable(conn).then(res => {
+      expect(res.status).toEqual(200);
+      expect(typeof res.body).toEqual('object');
     }));
 });


### PR DESCRIPTION
Not sure what the best way to go about handling people with older versions of Stardog.  Getting all the default database properties and values doesn't currently exist.  I could send back a hardcoded object?  Same with new method that gets all database properties VALUES.  send a hardcoded object of all possible db properties using existing optons.get.  I would have to know which properties belong to which version, though, so I'd need the version.  Suggestions?