### PR TITLE
Add ability to import namespaces via string or file (new Stardog endpoints)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ bower_components/
 node_modules/
 .*~
 dist/**
+.vscode/
+.rpt2_cache/
+

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -6,6 +6,7 @@ const graph = require('./graph');
 const reasoning = require('./reasoning');
 const docs = require('./docs');
 const versioning = require('./versioning');
+const namespaces = require('./namespaces');
 
 module.exports = Object.assign(
   {},
@@ -16,5 +17,6 @@ module.exports = Object.assign(
   { docs },
   { versioning },
   { graph },
-  { reasoning }
+  { reasoning },
+  { namespaces }
 );

--- a/lib/db/main.js
+++ b/lib/db/main.js
@@ -2,10 +2,8 @@ const { fetch } = require('../fetch');
 const FormData = require('form-data');
 const qs = require('querystring');
 const flat = require('flat');
-const lodashGet = require('lodash/get');
 
 const { httpBody } = require('../response-transforms');
-const { get: getOptions } = require('./options');
 
 const dispatchChange = (conn, config, content, params = {}) => {
   const headers = conn.headers();
@@ -193,19 +191,6 @@ const remove = (
     params
   );
 
-const namespaces = (conn, database, params) =>
-  getOptions(conn, database, params).then(res => {
-    if (res.status === 200) {
-      const n = lodashGet(res, 'body.database.namespaces', []);
-      const names = n.reduce((memo, val) => {
-        const [key, value] = val.split('=');
-        return Object.assign({}, memo, { [key]: value });
-      }, {});
-      res.body = names;
-    }
-    return res;
-  });
-
 // options
 //  mimeType
 // params
@@ -237,6 +222,5 @@ module.exports = {
   clear,
   add,
   remove,
-  namespaces,
   exportData,
 };

--- a/lib/db/namespaces.js
+++ b/lib/db/namespaces.js
@@ -31,13 +31,15 @@ const get = (conn, database, params) => {
       return backwardsCompatGetNamespaces(conn, database, params);
     }
 
-    return httpBody(res).then(bodyRes => ({
-      ...bodyRes,
-      body: bodyRes.body.namespaces.reduce(
-        (memo, { prefix, name }) => Object.assign({}, memo, { [prefix]: name }),
-        {}
-      ),
-    }));
+    return httpBody(res).then(bodyRes =>
+      Object.assign({}, bodyRes, {
+        body: bodyRes.body.namespaces.reduce(
+          (memo, { prefix, name }) =>
+            Object.assign({}, memo, { [prefix]: name }),
+          {}
+        ),
+      })
+    );
   });
 };
 

--- a/lib/db/namespaces.js
+++ b/lib/db/namespaces.js
@@ -1,0 +1,74 @@
+const { fetch } = require('../fetch');
+const FormData = require('form-data');
+const { get: getOptions } = require('./options');
+const lodashGet = require('lodash/get');
+
+const { httpBody } = require('../response-transforms');
+
+// For Stardog <= 7.0.2 compatibility. Remove later.
+const backwardsCompatGetNamespaces = (conn, database, params) =>
+  getOptions(conn, database, params).then(res => {
+    if (res.status === 200) {
+      const n = lodashGet(res, 'body.database.namespaces', []);
+      const names = n.reduce((memo, keyValString) => {
+        const [key, value] = keyValString.split('=');
+        return Object.assign({}, memo, { [key]: value });
+      }, {});
+      res.body = names;
+    }
+    return res;
+  });
+
+const get = (conn, database, params) => {
+  const headers = conn.headers();
+  headers.set('Accept', 'application/json');
+  return fetch(conn.request(database, 'namespaces'), {
+    method: 'GET',
+    headers,
+  }).then(res => {
+    // Old version of Stardog:
+    if (res.status === 404) {
+      return backwardsCompatGetNamespaces(conn, database, params);
+    }
+
+    return httpBody(res).then(bodyRes => ({
+      ...bodyRes,
+      body: bodyRes.body.namespaces.reduce(
+        (memo, { prefix, name }) => Object.assign({}, memo, { [prefix]: name }),
+        {}
+      ),
+    }));
+  });
+};
+
+const set = (conn, database, fileOrContents, options = {}) => {
+  const headers = conn.headers();
+  headers.set('Accept', 'application/json');
+  let body;
+
+  if (typeof fileOrContents === 'string') {
+    headers.set('Content-Type', options.contentType || 'text/turtle');
+    body = fileOrContents;
+  } else {
+    headers.set('Content-Type', 'multipart/form-data');
+    body = new FormData();
+    body.append('upload', fileOrContents);
+    // Copy over formData headers, since node-fetch 2+ apparently doesn't do this
+    // automatically. See: https://github.com/bitinn/node-fetch/issues/368
+    const formDataHeaders = body.getHeaders();
+    Object.keys(formDataHeaders).forEach(key => {
+      headers.set(key, formDataHeaders[key]);
+    });
+  }
+
+  return fetch(conn.request(database, 'namespaces'), {
+    method: 'POST',
+    headers,
+    body,
+  }).then(httpBody);
+};
+
+module.exports = {
+  get,
+  set,
+};

--- a/lib/db/namespaces.js
+++ b/lib/db/namespaces.js
@@ -55,12 +55,15 @@ const set = (conn, database, fileOrContents, options = {}) => {
     headers.set('Content-Type', 'multipart/form-data');
     body = new FormData();
     body.append('upload', fileOrContents);
-    // Copy over formData headers, since node-fetch 2+ apparently doesn't do this
-    // automatically. See: https://github.com/bitinn/node-fetch/issues/368
-    const formDataHeaders = body.getHeaders();
-    Object.keys(formDataHeaders).forEach(key => {
-      headers.set(key, formDataHeaders[key]);
-    });
+
+    if (body.getHeaders) {
+      // Copy over formData headers, since node-fetch 2+ apparently doesn't do this
+      // automatically. See: https://github.com/bitinn/node-fetch/issues/368
+      const formDataHeaders = body.getHeaders();
+      Object.keys(formDataHeaders).forEach(key => {
+        headers.set(key, formDataHeaders[key]);
+      });
+    }
   }
 
   return fetch(conn.request(database, 'namespaces'), {

--- a/lib/db/namespaces.js
+++ b/lib/db/namespaces.js
@@ -43,7 +43,7 @@ const get = (conn, database, params) => {
   });
 };
 
-const set = (conn, database, fileOrContents, options = {}) => {
+const add = (conn, database, fileOrContents, options = {}) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
   let body;
@@ -75,5 +75,5 @@ const set = (conn, database, fileOrContents, options = {}) => {
 
 module.exports = {
   get,
-  set,
+  add,
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -243,15 +243,6 @@ declare namespace Stardog {
         function remove(conn: Connection, database: string, transactionId: string, content: string, options: transaction.TransactionOptions, params?: object): Promise<transaction.TransactionResponse>;
 
         /**
-         * Gets a mapping of the namespaces used in a database.
-         *
-         * @param {Connection} conn the Stardog server connection
-         * @param {string} database the name of the database
-         * @param {object} params additional parameters if needed
-         */
-        function namespaces(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
-
-        /**
          * Exports the contents of a database.
          *
          * @param {Connection} conn the Stardog server connection
@@ -668,6 +659,26 @@ declare namespace Stardog {
              * @param {object} params additional parameters if needed
              */
             function get(conn: Connection, database: string, fileName: string, params?: object): Promise<HTTP.Body>;
+        }
+
+        namespace namespaces {
+          /**
+           * Gets a mapping of the namespaces used in a database.
+           *
+           * @param {Connection} conn the Stardog server connection
+           * @param {string} database the name of the database
+           * @param {object} params additional parameters if needed
+           */
+          function get(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
+
+          /**
+           * Gets a mapping of the namespaces used in a database.
+           *
+           * @param {Connection} conn the Stardog server connection
+           * @param {string} database the name of the database
+           * @param {object} params additional parameters if needed
+           */
+          function set(conn: Connection, database: string, fileOrContents: object | string): Promise<HTTP.Body>;
         }
     }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -672,13 +672,17 @@ declare namespace Stardog {
           function get(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
 
           /**
-           * Gets a mapping of the namespaces used in a database.
+           * Extracts namespaces from an RDF file or RDF string and adds any
+           * new namespaces to those that already exist in the database.
            *
            * @param {Connection} conn the Stardog server connection
            * @param {string} database the name of the database
-           * @param {object} params additional parameters if needed
+           * @param {object|string} fileOrContents an RDF file or RDF string
+           * @param {object} options an object specifying the contentType of
+           *  the RDF string; used only if `fileOrContents` is a string and
+           *  defaults to 'text/turtle'
            */
-          function set(conn: Connection, database: string, fileOrContents: object | string): Promise<HTTP.Body>;
+          function add(conn: Connection, database: string, fileOrContents: object | string, options?: { contentType?: HTTP.RdfMimeType }): Promise<HTTP.Body>;
         }
     }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -672,8 +672,8 @@ declare namespace Stardog {
           function get(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
 
           /**
-           * Extracts namespaces from an RDF file or RDF string and adds any
-           * new namespaces to those that already exist in the database.
+           * Extracts namespaces from an RDF file or RDF string and adds new
+           * and updates existing namespaces in the database.
            *
            * @param {Connection} conn the Stardog server connection
            * @param {string} database the name of the database

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2540,14 +2539,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2566,14 +2563,12 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2688,8 +2683,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2716,7 +2710,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2839,7 +2832,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2970,8 +2962,7 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6601,8 +6592,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -6805,7 +6795,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
       "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -6815,15 +6804,13 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9558,7 +9545,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/test/fixtures/namespace_import.ttl
+++ b/test/fixtures/namespace_import.ttl
@@ -1,0 +1,6 @@
+@prefix : <http://example.org/issues#> .
+@prefix newNamespace: <http://newNamespace.com> .
+@prefix newNamespace2: <http://newNamespace2.com> .
+@prefix newNamespace3: <http://newNamespace3.com> .
+
+:something a newNamespace:Thing .

--- a/test/getNamespaces.spec.js
+++ b/test/getNamespaces.spec.js
@@ -8,7 +8,7 @@ const {
   ConnectionFactory,
 } = require('./setup-database');
 
-describe('getNamespaces()', () => {
+describe('namespaces.get()', () => {
   const database = generateDatabaseName();
   let conn;
 
@@ -20,7 +20,7 @@ describe('getNamespaces()', () => {
   });
 
   it('should retrieve the namespace prefix bindings for the database', () =>
-    db.namespaces(conn, database).then(res => {
+    db.namespaces.get(conn, database).then(res => {
       expect(res.status).toEqual(200);
       expect(res.body).toEqual({
         '': 'http://example.org/issues#',

--- a/test/importNamespaces.spec.js
+++ b/test/importNamespaces.spec.js
@@ -10,7 +10,7 @@ const {
   ConnectionFactory,
 } = require('./setup-database');
 
-describe('namespaces.set()', () => {
+describe('namespaces.add()', () => {
   const database = generateDatabaseName();
   let conn;
 
@@ -23,7 +23,7 @@ describe('namespaces.set()', () => {
 
   it('should import namespaces from string contents', () =>
     db.namespaces
-      .set(conn, database, '@prefix newNamespace: <http://newNamespace.com> .')
+      .add(conn, database, '@prefix newNamespace: <http://newNamespace.com> .')
       .then(res => {
         expect(res.status).toBe(200);
         expect(res.body).toEqual({
@@ -45,7 +45,7 @@ describe('namespaces.set()', () => {
 
   it('should import namespaces from a file', () =>
     db.namespaces
-      .set(
+      .add(
         conn,
         database,
         fs.createReadStream(

--- a/test/importNamespaces.spec.js
+++ b/test/importNamespaces.spec.js
@@ -1,0 +1,75 @@
+/* eslint-env jest */
+
+const path = require('path');
+const fs = require('fs');
+const { db } = require('../lib');
+const {
+  seedDatabase,
+  dropDatabase,
+  generateDatabaseName,
+  ConnectionFactory,
+} = require('./setup-database');
+
+describe('namespaces.set()', () => {
+  const database = generateDatabaseName();
+  let conn;
+
+  beforeAll(seedDatabase(database));
+  afterAll(dropDatabase(database));
+
+  beforeEach(() => {
+    conn = ConnectionFactory();
+  });
+
+  it('should import namespaces from string contents', () =>
+    db.namespaces
+      .set(conn, database, '@prefix newNamespace: <http://newNamespace.com> .')
+      .then(res => {
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({
+          numImportedNamespaces: 1,
+          namespaces: expect.arrayContaining([
+            '=http://example.org/issues#',
+            'owl=http://www.w3.org/2002/07/owl#',
+            'foaf=http://xmlns.com/foaf/0.1/',
+            'paths=urn:paths:',
+            'rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+            'rdfs=http://www.w3.org/2000/01/rdf-schema#',
+            'stardog=tag:stardog:api:',
+            'xsd=http://www.w3.org/2001/XMLSchema#',
+            'ex=http://example.org/vehicles/',
+            'newNamespace=http://newNamespace.com',
+          ]),
+        });
+      }));
+
+  it('should import namespaces from a file', () =>
+    db.namespaces
+      .set(
+        conn,
+        database,
+        fs.createReadStream(
+          path.join(__dirname, 'fixtures', 'namespace_import.ttl')
+        )
+      )
+      .then(res => {
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({
+          numImportedNamespaces: 2,
+          namespaces: expect.arrayContaining([
+            '=http://example.org/issues#',
+            'owl=http://www.w3.org/2002/07/owl#',
+            'foaf=http://xmlns.com/foaf/0.1/',
+            'paths=urn:paths:',
+            'rdf=http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+            'rdfs=http://www.w3.org/2000/01/rdf-schema#',
+            'stardog=tag:stardog:api:',
+            'xsd=http://www.w3.org/2001/XMLSchema#',
+            'ex=http://example.org/vehicles/',
+            'newNamespace=http://newNamespace.com',
+            'newNamespace2=http://newNamespace2.com',
+            'newNamespace3=http://newNamespace3.com',
+          ]),
+        });
+      }));
+});


### PR DESCRIPTION
I'm not sold on calling the method for importing namespaces "set", since it doesn't _completely replace_ existing namespaces, but it was nicer in terms of corresponding to "get". What "set" actually does, as the test's filename indicates, is _add_ or _overwrite existing_ namespaces by importing from an RDF file; it doesn't _set_ the namespaces to _exactly_ those specified (e.g., if there is an existing namespace "foo=whatever" in the DB on the server, and the contents sent over HTTP consist in namespaces "bar=baz" and "blah=blah", the namespaces in the DB on the server when all is said and done will be "foo=whatever", "bar=baz", and "blah=blah" -- "foo=whatever" is not removed).

Seems okay to call it "set", though.