### PR TITLE
Allow `onResponseStart` to abort further stardog.js processing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,9 @@
 {
-  "extends": [
-    "airbnb-base",
-    "prettier"
-  ],
+  "extends": ["airbnb-base", "prettier"],
   "parserOptions": {
     "ecmaVersion": 6
   },
-  "plugins": [
-    "prettier"
-  ],
+  "plugins": ["prettier"],
   "rules": {
     "no-unused-vars": [
       "error",
@@ -16,9 +11,18 @@
         "argsIgnorePattern": "params"
       }
     ],
-    "prettier/prettier": ["warn", {
-      "singleQuote": true,
-      "trailingComma": "es5"
-    }]
+    "no-param-reassign": [
+      "error",
+      {
+        "props": false
+      }
+    ],
+    "prettier/prettier": [
+      "warn",
+      {
+        "singleQuote": true,
+        "trailingComma": "es5"
+      }
+    ]
   }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -697,7 +697,7 @@ declare namespace Stardog {
         }
 
         interface AdditionalHandlers {
-            onResponseStart(res: Response): void;
+            onResponseStart(res: Response): boolean | void;
         }
 
         /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -697,6 +697,14 @@ declare namespace Stardog {
         }
 
         interface AdditionalHandlers {
+            /**
+             * Specify this method if you wish to act on the HTTP response
+             * immediately, before any further stardog.js processing.
+             * NOTE: The stardog.js processing will continue, unless
+             * `onResponseStart` explicitly returns `false`.
+             * 
+             * @param {Response} res HTTP response object.
+             */
             onResponseStart(res: Response): boolean | void;
         }
 

--- a/lib/query/main.js
+++ b/lib/query/main.js
@@ -28,23 +28,25 @@ const dispatchQuery = (
     headers,
   });
 
-  if (additionalHandlers.onResponseStart) {
-    // Send back the response immediately when it is received if
-    // `onResponseStart` is defined. NOTE: The full results will still be
-    // returned, as well, when the promise chain below resolves.
-    fetchPromise.then(additionalHandlers.onResponseStart);
-  }
-
-  return fetchPromise.then(httpBody).then(res => {
-    // Paths queries will return duplicate variable names
-    // in body.head.vars (#135)
-    // e.g., `paths start ?x end ?y via ?p` will return
-    // ['x', 'x', 'p', 'y', 'y']. Use of a Set here
-    // simply eliminates the duplicates for things like Studio
-    if (res.body && res.body.head && res.body.head.vars) {
-      res.body.head.vars = [...new Set(res.body.head.vars)];
+  return fetchPromise.then(res => {
+    const shouldContinue = !additionalHandlers.onResponseStart
+      ? true
+      : additionalHandlers.onResponseStart(res);
+    if (!shouldContinue) {
+      return;
     }
-    return res;
+
+    return httpBody(res).then(res => {
+      // Paths queries will return duplicate variable names
+      // in body.head.vars (#135)
+      // e.g., `paths start ?x end ?y via ?p` will return
+      // ['x', 'x', 'p', 'y', 'y']. Use of a Set here
+      // simply eliminates the duplicates for things like Studio
+      if (res.body && res.body.head && res.body.head.vars) {
+        res.body.head.vars = [...new Set(res.body.head.vars)];
+      }
+      return res;
+    });
   });
 };
 

--- a/lib/query/main.js
+++ b/lib/query/main.js
@@ -32,20 +32,21 @@ const dispatchQuery = (
     const shouldContinue = !additionalHandlers.onResponseStart
       ? true
       : additionalHandlers.onResponseStart(res);
-    if (!shouldContinue) {
-      return;
+
+    if (shouldContinue === false) {
+      return res;
     }
 
-    return httpBody(res).then(res => {
+    return httpBody(res).then(bodyRes => {
       // Paths queries will return duplicate variable names
       // in body.head.vars (#135)
       // e.g., `paths start ?x end ?y via ?p` will return
       // ['x', 'x', 'p', 'y', 'y']. Use of a Set here
       // simply eliminates the duplicates for things like Studio
-      if (res.body && res.body.head && res.body.head.vars) {
-        res.body.head.vars = [...new Set(res.body.head.vars)];
+      if (bodyRes.body && bodyRes.body.head && bodyRes.body.head.vars) {
+        bodyRes.body.head.vars = [...new Set(bodyRes.body.head.vars)];
       }
-      return res;
+      return bodyRes;
     });
   });
 };

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -348,6 +348,17 @@ describe('query.execute()', () => {
         expect(res.body.results.bindings).toHaveLength(33);
       });
     });
+
+    it('should prevent further processing when `onResponseStart` explicitly returns `false`', () => {
+      execute(`select distinct ?s where { ?s ?p ?o }`, undefined, undefined, {
+        onResponseStart() {
+          return false;
+        },
+      }).then(res => {
+        expect(res.status).toBe(200);
+        expect(res.body.results).not.toBeDefined();
+      });
+    });
   });
 
   describe('paths', () => {


### PR DESCRIPTION
By allowing `onResponseStart` to optionally return `false` (telling stardog.js that it should not continue processing the response itself), all processing of the Stardog response can be effectively "turned over" to the caller. This allows, for example, the caller to _stream_ the response without ever having `response.json()` (or some other response accumulator that stardog.js might call) being called on it by stardog.js.