### PR TITLE
Make old-style namespaces request actually get only the namespaces (fix #207)

### DIFF
--- a/lib/db/namespaces.js
+++ b/lib/db/namespaces.js
@@ -6,8 +6,8 @@ const lodashGet = require('lodash/get');
 const { httpBody } = require('../response-transforms');
 
 // For Stardog <= 7.0.2 compatibility. Remove later.
-const backwardsCompatGetNamespaces = (conn, database, params) =>
-  getOptions(conn, database, params).then(res => {
+const backwardsCompatGetNamespaces = (conn, database) =>
+  getOptions(conn, database, { database: { namespaces: null } }).then(res => {
     if (res.status === 200) {
       const n = lodashGet(res, 'body.database.namespaces', []);
       const names = n.reduce((memo, keyValString) => {
@@ -19,7 +19,7 @@ const backwardsCompatGetNamespaces = (conn, database, params) =>
     return res;
   });
 
-const get = (conn, database, params) => {
+const get = (conn, database) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
   return fetch(conn.request(database, 'namespaces'), {
@@ -28,7 +28,7 @@ const get = (conn, database, params) => {
   }).then(res => {
     // Old version of Stardog:
     if (res.status === 404) {
-      return backwardsCompatGetNamespaces(conn, database, params);
+      return backwardsCompatGetNamespaces(conn, database);
     }
 
     return httpBody(res).then(bodyRes =>

--- a/lib/db/options.js
+++ b/lib/db/options.js
@@ -32,7 +32,7 @@ const get = (conn, database, params) => {
     },
     // TODO now that `getAll` is available, remove use of DB_OPTIONS and require
     // user to specify which options they want
-    DB_OPTIONS // the default list of options to GET values for
+    params || DB_OPTIONS // the default list of options to GET values for
   )
     .then(httpBody)
     .then(res => {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -667,9 +667,8 @@ declare namespace Stardog {
            *
            * @param {Connection} conn the Stardog server connection
            * @param {string} database the name of the database
-           * @param {object} params additional parameters if needed
            */
-          function get(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
+          function get(conn: Connection, database: string): Promise<HTTP.Body>;
 
           /**
            * Extracts namespaces from an RDF file or RDF string and adds new


### PR DESCRIPTION
Test failures are all the expected ones for Stardog 7.