### PR TITLE
Handle commented-out prefix lines in queries (fix #228)

### DIFF
--- a/lib/query/utils.js
+++ b/lib/query/utils.js
@@ -3,16 +3,20 @@
 const startsWith = (str, search, pos) =>
   str.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
 
+const baseAndCommentsMatcher = /^((base\s+<[^>]*>\s*)|([\t ]*#([^\n\r]*)))([\r|\r\n|\n])/gim;
+const prefixMatcher = /prefix[^:]+:\s*<[^>]*>\s*/gi;
+const whitespaceMatcher = /\s/g;
+
 const queryType = query => {
   // Lifted from http://tinyurl.com/ybnd9wzl
   // i'm almost certain I'm going to have to revisit this.
   const q = query
+    // remove base information and comments
+    .replace(baseAndCommentsMatcher, '')
     // remove prefix information
-    .replace(/prefix[^:]+:\s*<[^>]*>\s*/gi, '')
-    // remove base information
-    .replace(/^((base\s+<[^>]*>\s*)|([\t ]*#([^\n\r]*)))([\r|\r\n|\n])/gim, '')
+    .replace(prefixMatcher, '')
     // flatten everything down into a single string
-    .replace(/\s/g, '')
+    .replace(whitespaceMatcher, '')
     .toLowerCase();
 
   if (startsWith(q, 'select')) {

--- a/test/queryUtils.spec.js
+++ b/test/queryUtils.spec.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+
+const { queryType } = require('../lib/query/utils');
+
+// TODO: More tests of this utility
+describe('queryType', () => {
+  // Test for issue #228
+  it('should correctly identify queries with commented-out prefixes', () => {
+    const query = `# PREFIX : <http://www.example.com>
+SELECT * { ?s ?p ?o }`;
+    expect(queryType(query)).toBe('select');
+  });
+});


### PR DESCRIPTION
We need to remove comments (and base) _before_ prefix information is removed; this was an error that we fixed in the TypeScript branch and now need to port back here. Doing things in this order actually [matches the Stardog behavior](https://github.com/stardog-union/stardog/blob/886cdbcd251082a207fbeae53a0ff1abf1c9e8b2/utils/rdf/main/src/com/complexible/common/rdf/query/SPARQLUtil.java#L155-L190).