### PR TITLE
Allow graphql.execute to accept additionalHandlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,7 +1339,7 @@ Returns [`Promise<HTTP.Body>`](#body)
 
 ## <a name="graphql">graphql</a>
 
-#### <a name="execute">`query.graphql.execute(conn, database, query, variables, params)`</a>
+#### <a name="execute">`query.graphql.execute(conn, database, query, variables, params, additionalHandlers)`</a>
 
 Executes a GraphQL query
 
@@ -1354,6 +1354,8 @@ Expects the following parameters:
 - variables (`object`)
 
 - params (`object`)
+
+- additionalHandlers ([`AdditionalHandlers`](#additionalhandlers))
 
 Returns [`Promise<HTTP.Body>`](#body)
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -846,8 +846,9 @@ declare namespace Stardog {
              * @param {string} query the query to run
              * @param {object} variables Variable definitions for the query
              * @param {object} params additional parameters if needed
+             * @param {object} additionalHandlers additional response handlers (currently only `onResponseStart`)
              */
-            function execute(conn: Connection, database: string, query: string, variables?: object, params?: object): Promise<HTTP.Body>
+            function execute(conn: Connection, database: string, query: string, variables?: object, params?: object, additionalHandlers?: AdditionalHandlers): Promise<HTTP.Body>
 
             /**
              * Retrieves a list of GraphQL schemas in the database

--- a/lib/query/graphql.js
+++ b/lib/query/graphql.js
@@ -2,7 +2,14 @@ const { fetch } = require('../fetch');
 const qs = require('querystring');
 const { httpBody } = require('../response-transforms');
 
-const execute = (conn, database, query, variables = {}, params = {}) => {
+const execute = (
+  conn,
+  database,
+  query,
+  variables = {},
+  params = {},
+  additionalHandlers = {}
+) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'application/json');
 
@@ -14,7 +21,17 @@ const execute = (conn, database, query, variables = {}, params = {}) => {
     method: 'POST',
     body: JSON.stringify({ query, variables }),
     headers,
-  }).then(httpBody);
+  }).then(res => {
+    const shouldContinue = !additionalHandlers.onResponseStart
+      ? true
+      : additionalHandlers.onResponseStart(res);
+
+    if (shouldContinue === false) {
+      return res;
+    }
+
+    return httpBody(res);
+  });
 };
 
 const listSchemas = (conn, database, params = {}) => {


### PR DESCRIPTION
See https://github.com/stardog-union/stardog.js/tree/v2#additionalhandlers (currently only used by query.execute)