### PR TITLE
[STUD-528] Add Data Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2014,11 +2014,151 @@ Returns [`Promise<HTTP.Body>`](#body)
 
 #### <a name="status">`cluster.status(conn)`</a>
 
-Retrieves detailed status information about a Stardog cluster. 
+Retrieves detailed status information about a Stardog cluster.
 
 Expects the following parameters:
 
 - conn ([`Connection`](#connection))
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+## <a name="datasources">dataSources</a>
+
+#### <a name="list">`dataSources.list(conn)`</a>
+
+Retrieve a list of data sources
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="listinfo">`dataSources.listInfo(conn)`</a>
+
+Retrieve a list of data sources info
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="info">`dataSources.info(conn, name)`</a>
+
+Retrieve the named data source info
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="add">`dataSources.add(conn, name, options)`</a>
+
+Add a data source to the system
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+- options ([`T`](#t))
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="update">`dataSources.update(conn, name, options)`</a>
+
+Update the named data source in the system
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+- options ([`T`](#t))
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="remove">`dataSources.remove(conn, name)`</a>
+
+Remove the named data source from the system
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="online">`dataSources.online(conn, name)`</a>
+
+Bring the named data source online
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="available">`dataSources.available(conn, name)`</a>
+
+Determine if the named data source is available
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="options">`dataSources.options(conn, name)`</a>
+
+Retrieve the named data source options
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="getmetadata">`dataSources.getMetadata(conn, name, options)`</a>
+
+Retrieve the named data source metadata
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+- options (`object`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="updatemetadata">`dataSources.updateMetadata(conn, name, metadata, options)`</a>
+
+Update the named data source metadata
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+- metadata ([`T`](#t))
+
+- options (`object`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 

--- a/lib/dataSources.js
+++ b/lib/dataSources.js
@@ -82,18 +82,18 @@ const options = (conn, name) => {
   }).then(httpBody);
 };
 
-const getMetadata = (conn, name, options = {}) => {
+const getMetadata = (conn, name, opts = {}) => {
   const headers = conn.headers();
-  headers.set('Accept', options.accept || 'text/turtle');
+  headers.set('Accept', opts.accept || 'text/turtle');
 
   return fetch(conn.request('admin', 'data_sources', name, 'metadata'), {
     headers,
   }).then(httpBody);
 };
 
-const updateMetadata = (conn, name, metadata, options = {}) => {
+const updateMetadata = (conn, name, metadata, opts = {}) => {
   const headers = conn.headers();
-  headers.set('Content-Type', options.contentType || 'text/turtle');
+  headers.set('Content-Type', opts.contentType || 'text/turtle');
 
   return fetch(conn.request('admin', 'data_sources', name, 'metadata'), {
     method: 'PUT',

--- a/lib/dataSources.js
+++ b/lib/dataSources.js
@@ -1,0 +1,117 @@
+const { fetch } = require('./fetch');
+
+const { httpBody } = require('./response-transforms');
+
+const list = conn => {
+  const headers = conn.headers();
+  return fetch(conn.request('admin', 'data_sources'), {
+    headers,
+  }).then(httpBody);
+};
+
+const listInfo = conn => {
+  const headers = conn.headers();
+  return fetch(conn.request('admin', 'data_sources', 'list'), {
+    headers,
+  }).then(httpBody);
+};
+
+const info = (conn, name) => {
+  const headers = conn.headers();
+  headers.set('Content-Type', 'application/json');
+  return fetch(conn.request('admin', 'data_sources', name, 'info'), {
+    headers,
+  }).then(httpBody);
+};
+
+const add = (conn, name, options) => {
+  const headers = conn.headers();
+  headers.set('Content-Type', 'application/json');
+  return fetch(conn.request('admin', 'data_sources'), {
+    method: 'POST',
+    body: JSON.stringify({
+      name,
+      options,
+    }),
+    headers,
+  }).then(httpBody);
+};
+
+const update = (conn, name, options) => {
+  const headers = conn.headers();
+  headers.set('Content-Type', 'application/json');
+  return fetch(conn.request('admin', 'data_sources', name), {
+    method: 'PUT',
+    body: JSON.stringify({
+      name,
+      options,
+    }),
+    headers,
+  }).then(httpBody);
+};
+
+const remove = (conn, name) => {
+  const headers = conn.headers();
+  return fetch(conn.request('admin', 'data_sources', name), {
+    method: 'DELETE',
+    headers,
+  }).then(httpBody);
+};
+
+const online = (conn, name) => {
+  const headers = conn.headers();
+  headers.set('Accept', 'application/json');
+  return fetch(conn.request('admin', 'data_sources', name, 'online'), {
+    method: 'POST',
+    headers,
+  }).then(httpBody);
+};
+
+const available = (conn, name) => {
+  const headers = conn.headers();
+  headers.set('Accept', 'application/json');
+  return fetch(conn.request('admin', 'data_sources', name, 'available'), {
+    headers,
+  }).then(httpBody);
+};
+
+const options = (conn, name) => {
+  const headers = conn.headers();
+  return fetch(conn.request('admin', 'data_sources', name, 'options'), {
+    headers,
+  }).then(httpBody);
+};
+
+const getMetadata = (conn, name, options = {}) => {
+  const headers = conn.headers();
+  headers.set('Accept', options.accept || 'text/turtle');
+
+  return fetch(conn.request('admin', 'data_sources', name, 'metadata'), {
+    headers,
+  }).then(httpBody);
+};
+
+const updateMetadata = (conn, name, metadata, options = {}) => {
+  const headers = conn.headers();
+  headers.set('Content-Type', options.contentType || 'text/turtle');
+
+  return fetch(conn.request('admin', 'data_sources', name, 'metadata'), {
+    method: 'PUT',
+    body: metadata,
+    headers,
+  }).then(httpBody);
+};
+
+module.exports = {
+  list,
+  listInfo,
+  info,
+  add,
+  update,
+  remove,
+  online,
+  available,
+  options,
+  getMetadata,
+  updateMetadata,
+};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1282,11 +1282,104 @@ declare namespace Stardog {
         function info(conn: Connection): Promise<HTTP.Body>;
 
         /** 
-         * Retrieves detailed status information about a Stardog cluster. 
+         * Retrieves detailed status information about a Stardog cluster.
          * 
          * @param {Connection} conn the Stardog server connection
          */
         function status(conn: Connection): Promise<HTTP.Body>;
+    }
+
+    export namespace dataSources {
+        /**
+         * Retrieve a list of data sources
+         *
+         * @param {Connection} conn the Stardog server connection
+         */
+        function list(conn: Connection): Promise<HTTP.Body>;
+
+        /**
+         * Retrieve a list of data sources info
+         *
+         * @param {Connection} conn the Stardog server connection
+         */
+        function listInfo(conn: Connection): Promise<HTTP.Body>;
+
+        /**
+         * Retrieve the named data source info
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         */
+        function info(conn: Connection, name: string): Promise<HTTP.Body>;
+
+        /**
+         * Add a data source to the system
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         * @param {Options} options the JDBC (and other) options for the data source
+         */
+        function add<T>(conn: Connection, name: string, options: T): Promise<HTTP.Body>;
+
+        /**
+         * Update the named data source in the system
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         * @param {Options} options the JDBC (and other) options for the data source
+         */
+        function update<T>(conn: Connection, name: string, options: T): Promise<HTTP.Body>;
+
+        /**
+         * Remove the named data source from the system
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         */
+        function remove(conn: Connection, name: string): Promise<HTTP.Body>;
+
+        /**
+         * Bring the named data source online
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         */
+        function online(conn: Connection, name: string): Promise<HTTP.Body>;
+
+        /**
+         * Determine if the named data source is available
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         */
+        function available(conn: Connection, name: string): Promise<HTTP.Body>;
+
+        /**
+         * Retrieve the named data source options
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         */
+        function options(conn: Connection, name: string): Promise<HTTP.Body>;
+
+        /**
+         * Retrieve the named data source metadata
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         * @param {object} options additional options if needed
+         */
+        function getMetadata(conn: Connection, name: string, options: object): Promise<HTTP.Body>;
+
+        /**
+         * Update the named data source metadata
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         * @param {Metadata} metadata the data source metadata
+         * @param {object} options additional options if needed
+         */
+        function updateMetadata<T>(conn: Connection, name: string, metadata: T, options: object): Promise<HTTP.Body>;
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const Stardog = {
   cluster: require('./cluster'),
   virtualGraphs: require('./virtualGraphs'),
   storedFunctions: require('./storedFunctions'),
+  dataSources: require('./dataSources'),
 };
 
 module.exports = Stardog;

--- a/test/dataSources.spec.js
+++ b/test/dataSources.spec.js
@@ -32,7 +32,7 @@ describe('data_sources', () => {
       if (!exists) {
         return dataSources.add(conn, aDSName, aOptions);
       }
-      return Promise.resolve({ status: 201 });
+      return res;
     });
 
   const assureNotExists = () =>
@@ -42,7 +42,7 @@ describe('data_sources', () => {
       if (exists) {
         return dataSources.remove(conn, aDSName);
       }
-      return Promise.resolve({ status: 204 });
+      return res;
     });
 
   describe('list', () => {

--- a/test/dataSources.spec.js
+++ b/test/dataSources.spec.js
@@ -1,0 +1,154 @@
+/* eslint-env jest */
+
+const fs = require('fs');
+const path = require('path');
+const dataSources = require('../lib/dataSources');
+const { ConnectionFactory } = require('./setup-database');
+
+const dataSourceMetadata = fs.readFileSync(
+  path.resolve(`${__dirname}/fixtures/data_source_metadata.ttl`),
+  'utf8'
+);
+
+describe('data_sources', () => {
+  let conn;
+  const aDSName = 'MyDataSource';
+  const aOptions = {
+    'jdbc.driver': 'com.mysql.jdbc.Driver',
+    'jdbc.url': 'jdbc:mysql://localhost:3306/sys',
+    'jdbc.username': 'root',
+    'jdbc.password': '',
+    'ext.serverTimezone': 'EST',
+  };
+
+  beforeEach(() => {
+    conn = ConnectionFactory();
+  });
+
+  const assureExists = () =>
+    dataSources.list(conn).then(res => {
+      const exists =
+        res.body.data_sources && res.body.data_sources.includes(aDSName);
+      if (!exists) {
+        return dataSources.add(conn, aDSName, aOptions);
+      }
+      return Promise.resolve({ status: 201 });
+    });
+
+  const assureNotExists = () =>
+    dataSources.list(conn).then(res => {
+      const exists =
+        res.body.data_sources && res.body.data_sources.includes(aDSName);
+      if (exists) {
+        return dataSources.remove(conn, aDSName);
+      }
+      return Promise.resolve({ status: 204 });
+    });
+
+  describe('list', () => {
+    it('retrieves a list of data sources', () =>
+      dataSources.list(conn).then(res => {
+        expect(res.status).toBe(200);
+        expect(res.body.data_sources).toBeInstanceOf(Array);
+      }));
+  });
+
+  describe.only('listInfo', () => {
+    it('retrieves a list of data source info', () =>
+      dataSources.listInfo(conn).then(res => {
+        expect(res.status).toBe(200);
+        expect(res.body.data_sources).toBeInstanceOf(Array);
+      }));
+  });
+
+  describe('info', () => {
+    it('retrieves an exsiting data source info', () =>
+      assureExists()
+        .then(() => dataSources.info(conn, aDSName))
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.info).toBeInstanceOf(Object);
+        }));
+  });
+
+  describe('add', () => {
+    it('adds a data source', () =>
+      assureNotExists()
+        .then(() => dataSources.add(conn, aDSName, aOptions))
+        .then(res => {
+          expect(res.status).toBe(201);
+        }));
+  });
+
+  describe('update', () => {
+    it('updates an existing data source', () =>
+      assureExists()
+        .then(() => dataSources.update(conn, aDSName, aOptions))
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body).toBeInstanceOf(Object);
+        }));
+  });
+
+  describe('remove', () => {
+    it('removes an existing data source', () =>
+      assureExists()
+        .then(() => dataSources.remove(conn, aDSName))
+        .then(res => {
+          expect(res.status).toBe(204);
+        }));
+  });
+
+  // Skip dataSources.online because not sure how to create an "offline" data source
+  // describe.only('online', () => {
+  //   it('brings a private data source online', () =>
+  //     assurePrivateExists()
+  //       .then(() => dataSources.online(conn, aDSName))
+  //       .then(res => {
+  //         console.log(res)
+  //         expect(res.status).toBe(200);
+  //         expect(res.body.available).toBe(true);
+  //       }));
+  // });
+
+  describe('available', () => {
+    it('returns true when a data source is available', () =>
+      assureExists()
+        .then(() => dataSources.available(conn, aDSName))
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.available).toBe(true);
+        }));
+  });
+
+  describe('options', () => {
+    it('returns the options of a data source', () =>
+      assureExists()
+        .then(() => dataSources.options(conn, aDSName))
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.options).toEqual(aOptions);
+        }));
+  });
+
+  describe('getMetadata', () => {
+    it('returns the metadata of a data source', () =>
+      assureExists()
+        .then(() => dataSources.getMetadata(conn, aDSName))
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body).toEqual(dataSourceMetadata);
+        }));
+  });
+
+  describe('updateMetadata', () => {
+    it('updates the metadata of a data source', () =>
+      assureExists()
+        .then(() =>
+          dataSources.updateMetadata(conn, aDSName, dataSourceMetadata)
+        )
+        .then(res => {
+          expect(res.status).toBe(204);
+        }));
+  });
+});

--- a/test/fixtures/data_source_metadata.ttl
+++ b/test/fixtures/data_source_metadata.ttl
@@ -1,0 +1,27 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix tbl: <http://system.stardog.com/registry/jdbcDataSource/tableMetadata/table/> .
+@prefix swrlb: <http://www.w3.org/2003/11/swrlb#> .
+@prefix col: <http://system.stardog.com/registry/jdbcDataSource/tableMetadata/column/> .
+@prefix qtdef: <http://system.stardog.com/registry/jdbcDataSource/table/table#> .
+@prefix tblmd: <http://system.stardog.com/registry/jdbcDataSource/tableMetadata/> .
+@prefix : <http://api.stardog.com/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tbldef: <http://system.stardog.com/registry/jdbcDataSource/tableMetadata/table#> .
+@prefix jdbcmd: <http://system.stardog.com/registry/jdbcDataSourceMetadata/> .
+@prefix tbltype: <http://system.stardog.com/registry/jdbcDataSource/table/tableType/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix coldef: <http://system.stardog.com/registry/jdbcDataSource/tableMetadata/column#> .
+@prefix swrl: <http://www.w3.org/2003/11/swrl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix qt: <http://system.stardog.com/registry/jdbcDataSource/table/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix jdbcds: <http://system.stardog.com/registry/jdbcDataSource/> .
+@prefix reg: <http://system.stardog.com/registry/> .
+@prefix stardog: <tag:stardog:api:> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+<data-source://MyDataSource> jdbcmd:name "MyDataSource" .


### PR DESCRIPTION
[STUD-528]

You can run the full test suite by removing the `describe.only` as long as you have a running MySQL server with an empty password for the root user on port 3306 (default for MySQL) and the [JDBC Driver for MySQL](https://dev.mysql.com/downloads/connector/j/) in copied into your `stardog_install_dir/server/dbms/` (see [Stardog Manual](https://www.stardog.com/docs/#_configuration)).

[STUD-528]: https://stardog.atlassian.net/browse/STUD-528