### PR TITLE
[VET-1472] Implement new data source query API in stardog.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stardog-eps-docker.jfrog.io/stardog:latest
+FROM stardog/stardog
 ADD ./stardog-license-key.bin /var/opt/stardog/stardog-license-key.bin
 ADD ./test/fixtures/ /var/opt/stardog/test/fixtures/
 ADD ./.circleci/jwt.yaml /var/opt/stardog/jwt.yaml

--- a/README.md
+++ b/README.md
@@ -2202,3 +2202,45 @@ Expects the following parameters:
 
 Returns [`Promise<HTTP.Body>`](#body)
 
+#### <a name="query">`dataSources.query(conn, name, dataSourceQuery)`</a>
+
+Query data source
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+- dataSourceQuery (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="refreshcounts">`dataSources.refreshCounts(conn, name, tableName)`</a>
+
+Refresh table row-count estimates
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+- tableName (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="refreshmetadata">`dataSources.refreshMetadata(conn, name, tableName)`</a>
+
+Refresh metadata
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- name (`string`)
+
+- tableName (`string`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+

--- a/lib/dataSources.js
+++ b/lib/dataSources.js
@@ -118,17 +118,73 @@ const updateMetadata = (conn, name, metadata, opts = {}) => {
   }).then(httpBody);
 };
 
+/** Query data source */
+const query = (conn, name, dataSourceQuery) => {
+  const headers = conn.headers();
+  headers.set('Content-Type', 'text/plain');
+  headers.set('Accept', 'application/json');
+
+  return fetch(conn.request('admin', 'data_sources', name, 'query'), {
+    method: 'POST',
+    body: dataSourceQuery,
+    headers,
+  }).then(httpBody);
+};
+
+/** Refresh table row-count estimates */
+const refreshCounts = (conn, name, tableName = '') => {
+  const headers = conn.headers();
+  headers.set('Content-Type', 'application/json');
+  headers.set('Accept', 'application/json');
+
+  const body = {};
+  if (tableName) {
+    body.name = tableName;
+  }
+
+  return fetch(conn.request('admin', 'data_sources', name, 'refresh_counts'), {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers,
+  }).then(httpBody);
+};
+
+/** Refresh table row-count estimates */
+const refreshMetadata = (conn, name, tableName = '') => {
+  const headers = conn.headers();
+  headers.set('Content-Type', 'application/json');
+  headers.set('Accept', 'application/json');
+
+  const body = {};
+  if (tableName) {
+    body.name = tableName;
+  }
+
+  return fetch(
+    conn.request('admin', 'data_sources', name, 'refresh_metadata'),
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers,
+    }
+  ).then(httpBody);
+};
+
 module.exports = {
-  list,
+  available,
+  query,
+  refreshCounts,
   listInfo,
-  info,
-  add,
   update,
   remove,
-  share,
   online,
-  available,
+  info,
+  refreshMetadata,
+  share,
+  list,
+  add,
   options,
+
   getMetadata,
   updateMetadata,
 };

--- a/lib/dataSources.js
+++ b/lib/dataSources.js
@@ -118,7 +118,6 @@ const updateMetadata = (conn, name, metadata, opts = {}) => {
   }).then(httpBody);
 };
 
-/** Query data source */
 const query = (conn, name, dataSourceQuery) => {
   const headers = conn.headers();
   headers.set('Content-Type', 'text/plain');
@@ -131,7 +130,6 @@ const query = (conn, name, dataSourceQuery) => {
   }).then(httpBody);
 };
 
-/** Refresh table row-count estimates */
 const refreshCounts = (conn, name, tableName = '') => {
   const headers = conn.headers();
   headers.set('Content-Type', 'application/json');
@@ -149,7 +147,6 @@ const refreshCounts = (conn, name, tableName = '') => {
   }).then(httpBody);
 };
 
-/** Refresh table row-count estimates */
 const refreshMetadata = (conn, name, tableName = '') => {
   const headers = conn.headers();
   headers.set('Content-Type', 'application/json');

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,9 +3,9 @@
 /** stardog.js: The Stardog JS API*/
 
 import {
-  Headers,
-  Request,
-  RequestInit,
+    Headers,
+    Request,
+    RequestInit
 } from 'node-fetch';
 
 declare namespace Stardog {
@@ -1408,6 +1408,33 @@ declare namespace Stardog {
          * @param {object} options additional options if needed
          */
         function updateMetadata<T>(conn: Connection, name: string, metadata: T, options: object): Promise<HTTP.Body>;
+
+        /**
+         * Query data source
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         * @param {string} dataSourceQuery the data source query
+         */
+        function query(conn: Connection, name: string, dataSourceQuery: string): Promise<HTTP.Body>;
+
+        /**
+         * Refresh table row-count estimates
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         * @param {string} tableName optional data source table name
+         */
+        function refreshCounts(conn: Connection, name: string, tableName?: string): Promise<HTTP.Body>;
+
+        /**
+         * Refresh metadata
+         *
+         * @param {Connection} conn the Stardog server connection
+         * @param {string} name the data source name
+         * @param {string} tableName optional data source table name
+         */
+        function refreshMetadata(conn: Connection, name: string, tableName?: string): Promise<HTTP.Body>;
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
VET-1472

* added `query` data-source method
* added other (missing) data-source methods as well:
  * refreshCounts
  * refreshMetadata