### PR TITLE
use empty string for password if it is `undefined`

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -32,7 +32,7 @@ class Connection {
     const headers = new Headers();
     const authorization = this.token
       ? `bearer ${this.token}`
-      : `Basic ${base64.btoa(`${this.username}:${this.password}`)}`;
+      : `Basic ${base64.btoa(`${this.username}:${this.password || ''}`)}`;
     headers.set('Authorization', authorization);
     headers.set('Accept', '*/*');
 


### PR DESCRIPTION
otherwise we use the string `"undefined"` for the password