### PR TITLE
[DO NOT MERGE] release candidate for v3.5.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @alex-r-bigelow @anneeb @hasibhassan @jhartling @joshhk72 @SpiralP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [**v4.1.0**](https://github.com/stardog-union/stardog.js/milestone/52)
+- [**273**](https://github.com/stardog-union/stardog.js/pull/273) [VET-1900] Remove icv.clear and icv.convert
+- [**271**](https://github.com/stardog-union/stardog.js/pull/271) [VET-1380] Add `admin/status/whoami`
+
+## [**v4.0.0**](https://github.com/stardog-union/stardog.js/milestone/51)
+- [**268**](https://github.com/stardog-union/stardog.js/pull/268) [VET-1900] Remove ICV add/remove
+
+## [**v3.5.0**](https://github.com/stardog-union/stardog.js/milestone/53)
+- [**275**](https://github.com/stardog-union/stardog.js/issues/275) [VET-1380] Add `admin/status/whoami`
+
+## [**v3.4.0**](https://github.com/stardog-union/stardog.js/milestone/50)
+- [**270**](https://github.com/stardog-union/stardog.js/pull/270) [VET-1921] Add rename stored query to stardog.js
+- [**267**](https://github.com/stardog-union/stardog.js/pull/267) [VET-1899] Deprecate ICV add/remove
+
 ## [**v3.3.0**](https://github.com/stardog-union/stardog.js/milestone/49)
 - [**265**](https://github.com/stardog-union/stardog.js/pull/265) [VET-1472] Implement new data source query API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## [**v4.1.0**](https://github.com/stardog-union/stardog.js/milestone/52)
-- [**273**](https://github.com/stardog-union/stardog.js/pull/273) [VET-1900] Remove icv.clear and icv.convert
-- [**271**](https://github.com/stardog-union/stardog.js/pull/271) [VET-1380] Add `admin/status/whoami`
-
-## [**v4.0.0**](https://github.com/stardog-union/stardog.js/milestone/51)
-- [**268**](https://github.com/stardog-union/stardog.js/pull/268) [VET-1900] Remove ICV add/remove
-
 ## [**v3.5.0**](https://github.com/stardog-union/stardog.js/milestone/53)
 - [**275**](https://github.com/stardog-union/stardog.js/issues/275) [VET-1380] Add `admin/status/whoami`
 

--- a/README.md
+++ b/README.md
@@ -699,6 +699,9 @@ Returns [`Promise<HTTP.Body>`](#body)
 
 Removes all integrity constraints from a given database.
 
+DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+and removed in Stardog 8.0.0.
+
 Expects the following parameters:
 
 - conn ([`Connection`](#connection))
@@ -712,6 +715,9 @@ Returns [`Promise<HTTP.Body>`](#body)
 #### <a name="convert">`db.icv.convert(conn, database, icvAxioms, options, params)`</a>
 
 Converts a set of integrity constraints into an equivalent SPARQL query for a given database.
+
+DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+and removed in Stardog 8.0.0.
 
 Expects the following parameters:
 

--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,16 @@ Expects the following parameters:
 
 Returns [`Promise<HTTP.Body>`](#body)
 
+#### <a name="whoami">`user.whoAmI(conn)`</a>
+
+Returns the username for the given connection.
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+Returns [`Promise<HTTP.Body>`](#body)
+
 #### <a name="permission">Permission</a>
 
 Object with the following values:

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -411,6 +411,12 @@ declare namespace Stardog {
             /**
              * Removes all integrity constraints from a given database.
              *
+             * DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0.
+             *
+             * @deprecated Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0
+             *
              * @param {Connection} conn the Stardog server connection
              * @param {string} database the name of the database
              * @param {object} params additional parameters if needed
@@ -419,6 +425,12 @@ declare namespace Stardog {
 
             /**
              * Converts a set of integrity constraints into an equivalent SPARQL query for a given database.
+             *
+             * DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0.
+             *
+             * @deprecated Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0
              *
              * @param {Connection} conn the Stardog server connection
              * @param {string} database the name of the database

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1065,6 +1065,13 @@ declare namespace Stardog {
          */
         function token(conn: Connection): Promise<HTTP.Body>;
 
+        /**
+         * Returns the username for the given connection.
+         *
+         * @param {Connection} conn the Stardog server connection
+         */
+        function whoAmI(conn: Connection): Promise<HTTP.Body>;
+
         interface Permission {
             action: Action,
             resourceType: ResourceType,

--- a/lib/user/main.js
+++ b/lib/user/main.js
@@ -171,6 +171,13 @@ const token = conn => {
   }).then(httpBody);
 };
 
+const whoAmI = conn => {
+  const headers = conn.headers();
+  return fetch(conn.request('admin', 'status', 'whoami'), {
+    headers,
+  }).then(httpBody);
+};
+
 module.exports = {
   assignPermission,
   changePassword,
@@ -188,4 +195,5 @@ module.exports = {
   superUser,
   token,
   valid,
+  whoAmI,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stardog",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Stardog JavaScript Framework for node.js and the browser - Develop apps using the Stardog RDF Database & JS.",
   "keywords": [
     "stardog",

--- a/package.json
+++ b/package.json
@@ -129,5 +129,9 @@
       ]
     }
   },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
   "stardog-version": ">=7.0.0"
 }

--- a/test/whoAmI.spec.js
+++ b/test/whoAmI.spec.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+
+const { user } = require('../lib');
+const { ConnectionFactory } = require('./setup-database');
+
+describe('whoAmI', () => {
+  let conn;
+
+  beforeEach(() => {
+    conn = ConnectionFactory();
+  });
+
+  it("should return the current user's username.", () =>
+    user.whoAmI(conn).then(res => {
+      expect(res.status).toEqual(200);
+      expect(conn.username).toBeTruthy();
+      expect(res.body).toEqual(conn.username);
+    }));
+});


### PR DESCRIPTION
- mark icv.clear and icv.convert as deprecated