### PR TITLE
[VET-2486] Update flat package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2425,12 +2425,9 @@
       }
     },
     "flat": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-2.0.1.tgz",
-      "integrity": "sha1-cOKRiKdL4MPIlAnu0fqVd5B64y8=",
-      "requires": {
-        "is-buffer": "~1.1.2"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
     },
     "flat-cache": {
       "version": "1.3.0",
@@ -3443,7 +3440,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "fetch-ponyfill": "^6.0.0",
-    "flat": "^2.0.1",
+    "flat": "^5.0.2",
     "form-data": "^2.2.0",
     "isomorphic-base64": "^1.0.2",
     "lodash": "^4.17.4",


### PR DESCRIPTION
[VET-2486](https://stardog.atlassian.net/browse/VET-2486)

For proper parsing of db properties that share the start of their name with the full name of another property (ex: `security.properties.sensitive` vs `security.properties.sensitive.groups`

see diff: https://github.com/hughsk/flat/compare/v2.0.1...5.0.2