### PR TITLE
Re-add deprecated icv methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,65 @@ Expects the following parameters:
 
 Returns [`Promise<HTTP.Body>`](#body)
 
+#### <a name="add">`db.icv.add(conn, database, icvAxioms, options, params)`</a>
+
+Adds integrity constraints to a given database.
+
+DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using `db.add`.
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- database (`string`)
+
+- icvAxioms (`string`)
+
+- options ({ contentType: [`RdfMimeType`](#rdfmimetype) })
+
+- params (`object`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="remove">`db.icv.remove(conn, database, icvAxioms, options, params)`</a>
+
+Removes integrity constraints from a given database.
+
+DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using `db.remove`.
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- database (`string`)
+
+- icvAxioms (`string`)
+
+- options ({ contentType: [`RdfMimeType`](#rdfmimetype) })
+
+- params (`object`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
+#### <a name="clear">`db.icv.clear(conn, database, params)`</a>
+
+Removes all integrity constraints from a given database.
+
+DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using `db.remove`.
+
+Expects the following parameters:
+
+- conn ([`Connection`](#connection))
+
+- database (`string`)
+
+- params (`object`)
+
+Returns [`Promise<HTTP.Body>`](#body)
+
 #### <a name="validate">`db.icv.validate(conn, database, constraints, options, params)`</a>
 
 Checks constraints to see if they are valid

--- a/lib/db/icv.js
+++ b/lib/db/icv.js
@@ -12,6 +12,37 @@ const get = (conn, database, params = {}) => {
   }).then(httpBody);
 };
 
+const add = (conn, database, icvAxioms, options = {}, params = {}) => {
+  const headers = conn.headers();
+  headers.set('Content-Type', options.contentType || 'text/turtle');
+
+  return fetch(conn.request(database, 'icv', 'add'), {
+    method: 'POST',
+    body: icvAxioms,
+    headers,
+  }).then(httpBody);
+};
+
+const remove = (conn, database, icvAxioms, options = {}, params = {}) => {
+  const headers = conn.headers();
+  headers.set('Content-Type', options.contentType || 'text/turtle');
+
+  return fetch(conn.request(database, 'icv', 'remove'), {
+    method: 'POST',
+    body: icvAxioms,
+    headers,
+  }).then(httpBody);
+};
+
+const clear = (conn, database, params = {}) => {
+  const headers = conn.headers();
+
+  return fetch(conn.request(database, 'icv', 'clear'), {
+    method: 'POST',
+    headers,
+  }).then(httpBody);
+};
+
 const validate = (conn, database, constraints, options = {}, params = {}) => {
   const headers = conn.headers();
   headers.set('Content-Type', options.contentType || 'text/turtle');
@@ -148,7 +179,10 @@ const reportInTx = (
 };
 
 module.exports = {
+  add,
+  remove,
   get,
+  clear,
   validate,
   validateInTx,
   violations,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -375,6 +375,52 @@ declare namespace Stardog {
             function get(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
 
             /**
+             * Adds integrity constraints to a given database.
+             *
+             * DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using `db.add`.
+             *
+             * @deprecated Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using {@link db.add}.
+             *
+             * @param {Connection} conn the Stardog server connection
+             * @param {string} database the name of the database
+             * @param {string} icvAxioms an RDF block containing the axioms to be added
+             * @param {object} options an object specifying the contentType of the icvAxioms parameter. Default: text/turtle
+             * @param {object} params additional parameters if needed
+             */
+            function add(conn: Connection, database: string, icvAxioms: string, options?: { contentType: HTTP.RdfMimeType }, params?: object): Promise<HTTP.Body>;
+
+            /**
+             * Removes integrity constraints from a given database.
+             *
+             * DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using `db.remove`.
+             *
+             * @deprecated Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using {@link db.remove}.
+             *
+             * @param {Connection} conn the Stardog server connection
+             * @param {string} database the name of the database
+             * @param {string} icvAxioms an RDF block containing the axioms to be removed
+             * @param {object} options an object specifying the contentType of the icvAxioms parameter. Default: text/turtle
+             * @param {object} params additional parameters if needed
+             */
+            function remove(conn: Connection, database: string, icvAxioms: string, options?: { contentType: HTTP.RdfMimeType }, params?: object): Promise<HTTP.Body>;
+
+            /**
+             * Removes all integrity constraints from a given database.
+             *
+             * DEPRECATED: Support for storing ICV constraints in the system database is deprecated in Stardog 7.5.0
+             * and removed in Stardog 8.0.0; instead, SHACL constraints can be managed using `db.remove`.
+             *
+             * @param {Connection} conn the Stardog server connection
+             * @param {string} database the name of the database
+             * @param {object} params additional parameters if needed
+             */
+            function clear(conn: Connection, database: string, params?: object): Promise<HTTP.Body>;
+
+            /**
              * Checks constraints to see if they are valid
              *
              * @param {Connection} conn the Stardog server connection
@@ -936,7 +982,7 @@ declare namespace Stardog {
 
         /**
          * Adds a role to a user.
-         * 
+         *
          * @param {Connection} conn the Stardog server connection
          * @param {string} username the username of the user
          * @param {string} role the role to add to the user
@@ -1449,7 +1495,7 @@ declare namespace Stardog {
 
         /**
          * Get information about the data source types supported by the stardog instance, and their options
-         * 
+         *
          * @param {Connection} conn the Stardog server connection
          */
          function typeDescription(

--- a/test/icv.spec.js
+++ b/test/icv.spec.js
@@ -30,6 +30,47 @@ describe('icv', () => {
   );
   afterAll(dropDatabase(database));
 
+  // skipped as this is no longer supported in Stardog 8.0.0+
+  it.skip('should add integrity constraint axioms', () =>
+    icv
+      .add(conn, database, icvAxioms, { contentType: 'text/turtle' })
+      .then(res => {
+        expect(res.status).toBe(204);
+        return icv.get(conn, database);
+      })
+      .then(res => {
+        expect(res.status).toBe(200);
+        return icv.clear(conn, database);
+      }));
+
+  // skipped as this is no longer supported in Stardog 8.0.0+
+  it.skip('should remove integrity constraint axioms', () =>
+    icv
+      .add(conn, database, icvAxioms, { contentType: 'text/turtle' })
+      .then(() =>
+        icv.remove(conn, database, icvAxioms, { contentType: 'text/turtle' })
+      )
+      .then(res => {
+        expect(res.status).toBe(204);
+        return icv.get(conn, database);
+      })
+      .then(res => {
+        expect(res.status).toBe(200);
+      }));
+
+  // skipped as this is no longer supported in Stardog 8.0.0+
+  it.skip('should clear integrity constraint axioms', () =>
+    icv
+      .add(conn, database, icvAxioms, { contentType: 'text/turtle' })
+      .then(() => icv.clear(conn, database))
+      .then(res => {
+        expect(res.status).toBe(204);
+        return icv.get(conn, database);
+      })
+      .then(res => {
+        expect(res.status).toBe(200);
+      }));
+
   it('should validate constraints', () =>
     icv
       .validate(conn, database, icvAxioms, { contentType: 'text/turtle' })


### PR DESCRIPTION
Re-adding deprecated methods to support applications that are expected to connect to multiple Stardog versions (i.e. Studio)