### PR TITLE
[VET-2831] Update Stardog.js to allow arbitrary metadata for stored queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1223,7 +1223,7 @@ Expects the following parameters:
 
 Returns [`Promise<HTTP.Body>`](#body)
 
-#### <a name="update">`query.stored.update(conn, storedQuery, useUpdateMethod, options)`</a>
+#### <a name="update">`query.stored.update(conn, storedQuery, options, useUpdateMethod)`</a>
 
 Updates a given stored query and creates it if the name does not refer to an existing stored query.
 
@@ -1233,9 +1233,9 @@ Expects the following parameters:
 
 - storedQuery ([`StoredQueryOptions`](#storedqueryoptions))
 
-- useUpdateMethod (`boolean`)
-
 - options (`{ accept?: string = 'application/json', contentType?: string = 'application/json' }`)
+
+- useUpdateMethod (`boolean`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 

--- a/README.md
+++ b/README.md
@@ -1194,11 +1194,10 @@ Object with the following values:
 - shared (`boolean`)
 - reasoning (`boolean`)
 - description (`boolean`)
-- annotations (`Record<string, any>`)
 
 ## <a name="stored">stored</a>
 
-#### <a name="create">`query.stored.create(conn, config)`</a>
+#### <a name="create">`query.stored.create(conn, storedQuery, options)`</a>
 
 Stores a query in Stardog, either on the system level or for a given database.
 
@@ -1206,7 +1205,9 @@ Expects the following parameters:
 
 - conn ([`Connection`](#connection))
 
-- config ([`StoredQueryOptions`](#storedqueryoptions))
+- storedQuery ([`StoredQueryOptions | object`](#storedqueryoptions | object))
+
+- options (`{ accept?: string = 'application/json', contentType?: string = 'application/json' }`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 
@@ -1222,7 +1223,7 @@ Expects the following parameters:
 
 Returns [`Promise<HTTP.Body>`](#body)
 
-#### <a name="update">`query.stored.update(conn, config, useUpdateMethod)`</a>
+#### <a name="update">`query.stored.update(conn, storedQuery, useUpdateMethod, options)`</a>
 
 Updates a given stored query and creates it if the name does not refer to an existing stored query.
 
@@ -1230,9 +1231,11 @@ Expects the following parameters:
 
 - conn ([`Connection`](#connection))
 
-- config ([`StoredQueryOptions`](#storedqueryoptions))
+- storedQuery ([`StoredQueryOptions`](#storedqueryoptions))
 
 - useUpdateMethod (`boolean`)
+
+- options (`{ accept?: string = 'application/json', contentType?: string = 'application/json' }`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 

--- a/README.md
+++ b/README.md
@@ -1194,10 +1194,11 @@ Object with the following values:
 - shared (`boolean`)
 - reasoning (`boolean`)
 - description (`boolean`)
+- annotations (`Record<string, any>`)
 
 ## <a name="stored">stored</a>
 
-#### <a name="create">`query.stored.create(conn, config, params)`</a>
+#### <a name="create">`query.stored.create(conn, config)`</a>
 
 Stores a query in Stardog, either on the system level or for a given database.
 
@@ -1207,11 +1208,9 @@ Expects the following parameters:
 
 - config ([`StoredQueryOptions`](#storedqueryoptions))
 
-- params (`object`)
-
 Returns [`Promise<HTTP.Body>`](#body)
 
-#### <a name="list">`query.stored.list(conn, params)`</a>
+#### <a name="list">`query.stored.list(conn, options)`</a>
 
 Lists all stored queries.
 
@@ -1219,11 +1218,11 @@ Expects the following parameters:
 
 - conn ([`Connection`](#connection))
 
-- params (`object`)
+- options (`{ accept?: string = 'application/json' }`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 
-#### <a name="update">`query.stored.update(conn, config, params, useUpdateMethod)`</a>
+#### <a name="update">`query.stored.update(conn, config, useUpdateMethod)`</a>
 
 Updates a given stored query and creates it if the name does not refer to an existing stored query.
 
@@ -1233,13 +1232,11 @@ Expects the following parameters:
 
 - config ([`StoredQueryOptions`](#storedqueryoptions))
 
-- params (`object`)
-
 - useUpdateMethod (`boolean`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 
-#### <a name="remove">`query.stored.remove(conn, storedQuery, params)`</a>
+#### <a name="remove">`query.stored.remove(conn, storedQuery)`</a>
 
 Removes a given stored query.
 
@@ -1248,8 +1245,6 @@ Expects the following parameters:
 - conn ([`Connection`](#connection))
 
 - storedQuery (`string`)
-
-- params (`object`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -759,14 +759,14 @@ declare namespace Stardog {
              *
              * @param {Connection} conn the Stardog server connection
              * @param {StoredQueryOptions} storedQuery an object specifying the options to set on the updated query
-             * @param {boolean} useUpdateMethod whether to use Stardog's HTTP PUT method, added in version 6.2.0. Default: true
              * @param {object} options additional options to customize query
+             * @param {boolean} useUpdateMethod whether to use Stardog's HTTP PUT method, added in version 6.2.0. Default: true
              */
             function update(
                 conn: Connection,
                 storedQuery: StoredQueryOptions,
-                useUpdateMethod?: boolean = true,
-                options?: { accept?: string = 'application/json', contentType?: string = 'application/json' }
+                options?: { accept?: string = 'application/json', contentType?: string = 'application/json' },
+                useUpdateMethod?: boolean = true
             ): Promise<HTTP.Body>
 
             /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -739,7 +739,7 @@ declare namespace Stardog {
              *
              * @param {Connection} conn the Stardog server connection
              * @param {StoredQueryOptions} storedQuery an object specifying the options to set on the new query
-             * @param {object} options additional options to customize query
+             * @param {object} options additional request options
              */
             function create(
                 conn: Connection,
@@ -751,6 +751,7 @@ declare namespace Stardog {
              * Lists all stored queries.
              *
              * @param {Connection} conn the Stardog server connection
+             * @param {object} options additional request options
              */
             function list(conn: Connection, options?: { accept?: string }): Promise<HTTP.Body>;
 
@@ -759,7 +760,7 @@ declare namespace Stardog {
              *
              * @param {Connection} conn the Stardog server connection
              * @param {StoredQueryOptions} storedQuery an object specifying the options to set on the updated query
-             * @param {object} options additional options to customize query
+             * @param {object} options additional request options
              * @param {boolean} useUpdateMethod whether to use Stardog's HTTP PUT method, added in version 6.2.0. Default: true
              */
             function update(

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -730,12 +730,6 @@ declare namespace Stardog {
             /** Attributes introduced in Stardog version 6.2.2, which are optional in versions >= 6.2.2 and ignored in earlier versions. */
             reasoning?: boolean,
             description?: boolean,
-            /**
-             * [Extra arbitrary properties](https://docs.stardog.com/operating-stardog/database-administration/stored-queries#attaching-arbitrary-properties-to-stored-queries)
-             *
-             * Keys must be in the form of valid iris.
-             */
-            annotations?: Record<string, any>,
         }
 
         /** Manages stored queries. */
@@ -744,9 +738,14 @@ declare namespace Stardog {
              * Stores a query in Stardog, either on the system level or for a given database.
              *
              * @param {Connection} conn the Stardog server connection
-             * @param {StoredQueryOptions} config an object specifying the options to set on the new query
+             * @param {StoredQueryOptions} storedQuery an object specifying the options to set on the new query
+             * @param {object} options additional options to customize query
              */
-            function create(conn: Connection, config: StoredQueryOptions): Promise<HTTP.Body>
+            function create(
+                conn: Connection,
+                storedQuery: StoredQueryOptions | object,
+                options?: { accept?: string = 'application/json', contentType?: string = 'application/json' }
+            ): Promise<HTTP.Body>
 
             /**
              * Lists all stored queries.
@@ -756,13 +755,19 @@ declare namespace Stardog {
             function list(conn: Connection, options?: { accept?: string = 'application/json' }): Promise<HTTP.Body>
 
             /**
-                * Updates a given stored query and creates it if the name does not refer to an existing stored query.
-                *
-                * @param {Connection} conn the Stardog server connection
-                * @param {StoredQueryOptions} config an object specifying the options to set on the updated query
-                * @param {boolean} useUpdateMethod whether to use Stardog's HTTP PUT method, added in version 6.2.0. Default: true
-                */
-            function update(conn: Connection, config: StoredQueryOptions, useUpdateMethod?: boolean): Promise<HTTP.Body>
+             * Updates a given stored query and creates it if the name does not refer to an existing stored query.
+             *
+             * @param {Connection} conn the Stardog server connection
+             * @param {StoredQueryOptions} storedQuery an object specifying the options to set on the updated query
+             * @param {boolean} useUpdateMethod whether to use Stardog's HTTP PUT method, added in version 6.2.0. Default: true
+             * @param {object} options additional options to customize query
+             */
+            function update(
+                conn: Connection,
+                storedQuery: StoredQueryOptions,
+                useUpdateMethod?: boolean = true,
+                options?: { accept?: string = 'application/json', contentType?: string = 'application/json' }
+            ): Promise<HTTP.Body>
 
             /**
              * Removes a given stored query.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -744,15 +744,15 @@ declare namespace Stardog {
             function create(
                 conn: Connection,
                 storedQuery: StoredQueryOptions | object,
-                options?: { accept?: string = 'application/json', contentType?: string = 'application/json' }
-            ): Promise<HTTP.Body>
+                options?: { accept?: string, contentType?: string }
+            ): Promise<HTTP.Body>;
 
             /**
              * Lists all stored queries.
              *
              * @param {Connection} conn the Stardog server connection
              */
-            function list(conn: Connection, options?: { accept?: string = 'application/json' }): Promise<HTTP.Body>
+            function list(conn: Connection, options?: { accept?: string }): Promise<HTTP.Body>;
 
             /**
              * Updates a given stored query and creates it if the name does not refer to an existing stored query.
@@ -765,9 +765,9 @@ declare namespace Stardog {
             function update(
                 conn: Connection,
                 storedQuery: StoredQueryOptions,
-                options?: { accept?: string = 'application/json', contentType?: string = 'application/json' },
-                useUpdateMethod?: boolean = true
-            ): Promise<HTTP.Body>
+                options?: { accept?: string, contentType?: string },
+                useUpdateMethod?: boolean
+            ): Promise<HTTP.Body>;
 
             /**
              * Removes a given stored query.
@@ -775,7 +775,7 @@ declare namespace Stardog {
              * @param {Connection} conn the Stardog server connection
              * @param {string} storedQuery the name of the stored query to be removed
              */
-            function remove(conn: Connection, storedQuery: string): Promise<HTTP.Body>
+            function remove(conn: Connection, storedQuery: string): Promise<HTTP.Body>;
 
             /**
             * Renames a given stored query.
@@ -784,7 +784,7 @@ declare namespace Stardog {
             * @param {string} name the current name of the existing stored query
             * @param {string} newName the new name of the stored query
             */
-            function rename(conn: Connection, name: string, newName: string): Promise<HTTP.Body>
+            function rename(conn: Connection, name: string, newName: string): Promise<HTTP.Body>;
         }
 
         /** GraphQL queries and schema management */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -730,6 +730,12 @@ declare namespace Stardog {
             /** Attributes introduced in Stardog version 6.2.2, which are optional in versions >= 6.2.2 and ignored in earlier versions. */
             reasoning?: boolean,
             description?: boolean,
+            /**
+             * [Extra arbitrary properties](https://docs.stardog.com/operating-stardog/database-administration/stored-queries#attaching-arbitrary-properties-to-stored-queries)
+             *
+             * Keys must be in the form of valid iris.
+             */
+            annotations?: Record<string, any>,
         }
 
         /** Manages stored queries. */
@@ -739,36 +745,32 @@ declare namespace Stardog {
              *
              * @param {Connection} conn the Stardog server connection
              * @param {StoredQueryOptions} config an object specifying the options to set on the new query
-             * @param {object} params additional parameters if needed
              */
-            function create(conn: Connection, config: StoredQueryOptions, params?: object): Promise<HTTP.Body>
+            function create(conn: Connection, config: StoredQueryOptions): Promise<HTTP.Body>
 
             /**
              * Lists all stored queries.
              *
              * @param {Connection} conn the Stardog server connection
-             * @param {object} params additional parameters if needed
              */
-            function list(conn: Connection, params?: object): Promise<HTTP.Body>
+            function list(conn: Connection, options?: { accept?: string = 'application/json' }): Promise<HTTP.Body>
 
             /**
                 * Updates a given stored query and creates it if the name does not refer to an existing stored query.
                 *
                 * @param {Connection} conn the Stardog server connection
                 * @param {StoredQueryOptions} config an object specifying the options to set on the updated query
-                * @param {object} params additional parameters if needed
                 * @param {boolean} useUpdateMethod whether to use Stardog's HTTP PUT method, added in version 6.2.0. Default: true
                 */
-            function update(conn: Connection, config: StoredQueryOptions, params?: object, useUpdateMethod?: boolean): Promise<HTTP.Body>
+            function update(conn: Connection, config: StoredQueryOptions, useUpdateMethod?: boolean): Promise<HTTP.Body>
 
             /**
              * Removes a given stored query.
              *
              * @param {Connection} conn the Stardog server connection
              * @param {string} storedQuery the name of the stored query to be removed
-             * @param {object} params additional parameters if needed
              */
-            function remove(conn: Connection, storedQuery: string, params?: object): Promise<HTTP.Body>
+            function remove(conn: Connection, storedQuery: string): Promise<HTTP.Body>
 
             /**
             * Renames a given stored query.

--- a/lib/query/stored.js
+++ b/lib/query/stored.js
@@ -1,6 +1,42 @@
 const { fetch } = require('../fetch');
-const lodashPick = require('lodash/pick');
 const { httpBody } = require('../response-transforms');
+
+const convertToJsonLd = (conn, storedQuery) => {
+  const types = ['system:StoredQuery'];
+  if (storedQuery.shared) {
+    types.push('system:SharedQuery');
+  }
+  if (storedQuery.reasoning) {
+    types.push('system:ReasoningQuery');
+  }
+
+  const keyValuePairs = Object.entries({
+    'system:queryName': storedQuery.name,
+    'system:queryDescription': storedQuery.description,
+    'system:queryString': storedQuery.query,
+    'system:queryCreator': conn.username,
+    'system:queryDatabase': storedQuery.database,
+    ...storedQuery.annotations,
+  }).reduce((obj, [iri, value]) => {
+    if (typeof value !== 'undefined') {
+      obj[iri] = { '@value': value };
+    }
+    return obj;
+  }, {});
+
+  return {
+    '@context': {
+      system: 'http://system.stardog.com/',
+    },
+    '@graph': [
+      {
+        '@id': 'system:Query',
+        '@type': types,
+        ...keyValuePairs,
+      },
+    ],
+  };
+};
 
 /*
   body
@@ -9,39 +45,28 @@ const { httpBody } = require('../response-transforms');
     - query
     - shared boolean (defaults to false)
 */
-const create = (conn, storedQuery, params) => {
+const create = (conn, storedQuery) => {
   const headers = conn.headers();
-  headers.set('Content-Type', 'application/json; charset=utf-8');
+  headers.set('Content-Type', 'application/ld+json');
   headers.set('Accept', 'application/json');
-
-  const body = lodashPick(storedQuery, [
-    'name',
-    'database',
-    'query',
-    'shared',
-    'reasoning',
-    'description',
-  ]);
-  body.creator = conn.username;
-  body.shared = typeof body.shared === 'boolean' ? body.shared : false;
 
   return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
     method: 'POST',
-    body: JSON.stringify(body),
+    body: JSON.stringify(convertToJsonLd(conn, storedQuery)),
   }).then(httpBody);
 };
 
-const list = (conn, params) => {
+const list = (conn, options = {}) => {
   const headers = conn.headers();
-  headers.set('Accept', 'application/json');
+  headers.set('Accept', options.accept || 'application/json');
 
   return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
   }).then(httpBody);
 };
 
-const deleteStoredQuery = (conn, storedQuery, params) => {
+const deleteStoredQuery = (conn, storedQuery) => {
   const headers = conn.headers();
   headers.set('Accept', 'application/json');
 
@@ -64,47 +89,32 @@ const renameStoredQuery = (conn, name, newName) => {
   }).then(httpBody);
 };
 
-const replace = (conn, storedQuery, params) =>
+const replace = (conn, storedQuery) =>
   deleteStoredQuery(conn, storedQuery.name).then(deleteResponse => {
     //  Update creates when the query did not already exist
     if (deleteResponse.status === 404 || deleteResponse.ok) {
-      return create(conn, storedQuery, params);
+      return create(conn, storedQuery);
     }
     return deleteResponse;
   });
 
-const updateStoredQuery = (
-  conn,
-  storedQuery,
-  params,
-  useUpdateMethod = true
-) => {
+const updateStoredQuery = (conn, storedQuery, useUpdateMethod = true) => {
   if (!useUpdateMethod) {
-    return replace(conn, storedQuery, params);
+    return replace(conn, storedQuery);
   }
   const headers = conn.headers();
-  headers.set('Content-Type', 'application/json; charset=utf-8');
+  headers.set('Content-Type', 'application/ld+json');
   headers.set('Accept', 'application/json');
 
-  const body = lodashPick(storedQuery, [
-    'name',
-    'database',
-    'query',
-    'shared',
-    'reasoning',
-    'description',
-  ]);
-  body.creator = conn.username;
-  body.shared = typeof body.shared === 'boolean' ? body.shared : false;
   return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
     method: 'PUT',
-    body: JSON.stringify(body),
+    body: JSON.stringify(convertToJsonLd(conn, storedQuery)),
   })
     .then(httpBody)
     .then(updateResponse => {
       if (updateResponse.status === 405) {
-        return replace(conn, storedQuery, params);
+        return replace(conn, storedQuery);
       }
       return updateResponse;
     });

--- a/lib/query/stored.js
+++ b/lib/query/stored.js
@@ -77,8 +77,8 @@ const replace = (conn, storedQuery) =>
 const updateStoredQuery = (
   conn,
   storedQuery,
-  useUpdateMethod = true,
-  options = {}
+  options = {},
+  useUpdateMethod = true
 ) => {
   if (!useUpdateMethod) {
     return replace(conn, storedQuery);

--- a/lib/query/stored.js
+++ b/lib/query/stored.js
@@ -5,7 +5,7 @@ const CONTENT_TYPE_JSON = 'application/json';
 
 const getBody = (conn, storedQuery, options) => {
   if (!options.contentType || options.contentType === CONTENT_TYPE_JSON) {
-    const body = { ...storedQuery };
+    const body = Object.assign({}, storedQuery);
     body.creator = conn.username;
     body.shared = typeof body.shared === 'boolean' ? body.shared : false;
     return body;

--- a/lib/query/stored.js
+++ b/lib/query/stored.js
@@ -10,14 +10,18 @@ const convertToJsonLd = (conn, storedQuery) => {
     types.push('system:ReasoningQuery');
   }
 
-  const keyValuePairs = Object.entries({
-    'system:queryName': storedQuery.name,
-    'system:queryDescription': storedQuery.description,
-    'system:queryString': storedQuery.query,
-    'system:queryCreator': conn.username,
-    'system:queryDatabase': storedQuery.database,
-    ...storedQuery.annotations,
-  }).reduce((obj, [iri, value]) => {
+  const keyValuePairs = Object.entries(
+    Object.assign(
+      {
+        'system:queryName': storedQuery.name,
+        'system:queryDescription': storedQuery.description,
+        'system:queryString': storedQuery.query,
+        'system:queryCreator': conn.username,
+        'system:queryDatabase': storedQuery.database,
+      },
+      storedQuery.annotations
+    )
+  ).reduce((obj, [iri, value]) => {
     if (typeof value !== 'undefined') {
       obj[iri] = { '@value': value };
     }
@@ -29,11 +33,13 @@ const convertToJsonLd = (conn, storedQuery) => {
       system: 'http://system.stardog.com/',
     },
     '@graph': [
-      {
-        '@id': 'system:Query',
-        '@type': types,
-        ...keyValuePairs,
-      },
+      Object.assign(
+        {
+          '@id': 'system:Query',
+          '@type': types,
+        },
+        keyValuePairs
+      ),
     ],
   };
 };

--- a/lib/query/stored.js
+++ b/lib/query/stored.js
@@ -1,47 +1,17 @@
 const { fetch } = require('../fetch');
 const { httpBody } = require('../response-transforms');
 
-const convertToJsonLd = (conn, storedQuery) => {
-  const types = ['system:StoredQuery'];
-  if (storedQuery.shared) {
-    types.push('system:SharedQuery');
-  }
-  if (storedQuery.reasoning) {
-    types.push('system:ReasoningQuery');
-  }
+const CONTENT_TYPE_JSON = 'application/json';
 
-  const keyValuePairs = Object.entries(
-    Object.assign(
-      {
-        'system:queryName': storedQuery.name,
-        'system:queryDescription': storedQuery.description,
-        'system:queryString': storedQuery.query,
-        'system:queryCreator': conn.username,
-        'system:queryDatabase': storedQuery.database,
-      },
-      storedQuery.annotations
-    )
-  ).reduce((obj, [iri, value]) => {
-    if (typeof value !== 'undefined') {
-      obj[iri] = { '@value': value };
-    }
-    return obj;
-  }, {});
-
-  return {
-    '@context': {
-      system: 'http://system.stardog.com/',
-    },
-    '@graph': [
-      Object.assign(
-        {
-          '@id': 'system:Query',
-          '@type': types,
-        },
-        keyValuePairs
-      ),
-    ],
-  };
+const getBody = (conn, storedQuery, options) => {
+  if (!options.contentType || options.contentType === CONTENT_TYPE_JSON) {
+    const body = { ...storedQuery };
+    body.creator = conn.username;
+    body.shared = typeof body.shared === 'boolean' ? body.shared : false;
+    return body;
+  }
+  // pass storedQuery through
+  return storedQuery;
 };
 
 /*
@@ -51,21 +21,21 @@ const convertToJsonLd = (conn, storedQuery) => {
     - query
     - shared boolean (defaults to false)
 */
-const create = (conn, storedQuery) => {
+const create = (conn, storedQuery, options = {}) => {
   const headers = conn.headers();
-  headers.set('Content-Type', 'application/ld+json');
-  headers.set('Accept', 'application/json');
+  headers.set('Content-Type', options.contentType || CONTENT_TYPE_JSON);
+  headers.set('Accept', options.accept || CONTENT_TYPE_JSON);
 
   return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
     method: 'POST',
-    body: JSON.stringify(convertToJsonLd(conn, storedQuery)),
+    body: JSON.stringify(getBody(conn, storedQuery, options)),
   }).then(httpBody);
 };
 
 const list = (conn, options = {}) => {
   const headers = conn.headers();
-  headers.set('Accept', options.accept || 'application/json');
+  headers.set('Accept', options.accept || CONTENT_TYPE_JSON);
 
   return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
@@ -74,7 +44,7 @@ const list = (conn, options = {}) => {
 
 const deleteStoredQuery = (conn, storedQuery) => {
   const headers = conn.headers();
-  headers.set('Accept', 'application/json');
+  headers.set('Accept', CONTENT_TYPE_JSON);
 
   return fetch(conn.request('admin', 'queries', 'stored', storedQuery), {
     headers,
@@ -84,8 +54,8 @@ const deleteStoredQuery = (conn, storedQuery) => {
 
 const renameStoredQuery = (conn, name, newName) => {
   const headers = conn.headers();
-  headers.set('Content-Type', 'application/json; charset=utf-8');
-  headers.set('Accept', 'application/json');
+  headers.set('Content-Type', CONTENT_TYPE_JSON);
+  headers.set('Accept', CONTENT_TYPE_JSON);
 
   const body = { name: newName };
   return fetch(conn.request('admin', 'queries', 'stored', name), {
@@ -104,18 +74,23 @@ const replace = (conn, storedQuery) =>
     return deleteResponse;
   });
 
-const updateStoredQuery = (conn, storedQuery, useUpdateMethod = true) => {
+const updateStoredQuery = (
+  conn,
+  storedQuery,
+  useUpdateMethod = true,
+  options = {}
+) => {
   if (!useUpdateMethod) {
     return replace(conn, storedQuery);
   }
   const headers = conn.headers();
-  headers.set('Content-Type', 'application/ld+json');
-  headers.set('Accept', 'application/json');
+  headers.set('Content-Type', options.contentType || CONTENT_TYPE_JSON);
+  headers.set('Accept', options.accept || CONTENT_TYPE_JSON);
 
   return fetch(conn.request('admin', 'queries', 'stored'), {
     headers,
     method: 'PUT',
-    body: JSON.stringify(convertToJsonLd(conn, storedQuery)),
+    body: JSON.stringify(getBody(conn, storedQuery, options)),
   })
     .then(httpBody)
     .then(updateResponse => {

--- a/test/stored.spec.js
+++ b/test/stored.spec.js
@@ -33,6 +33,29 @@ describe('stored', () => {
           return stored.remove(conn, name);
         });
     });
+    it('allows annotations to be set', () => {
+      const name = generateRandomString();
+      return stored
+        .create(conn, {
+          name,
+          database,
+          query: 'select distinct ?type {?s a ?type}',
+          annotations: { 'iri:annotation:thing': 'is a string!' },
+        })
+        .then(res => {
+          expect(res.status).toBe(204);
+          return stored.list(conn, { accept: 'application/ld+json' });
+        })
+        .then(res => {
+          const storedQuery = res.body['@graph'].find(
+            v => v['system:queryName']['@value'] === name
+          );
+          expect(storedQuery['iri:annotation:thing']['@value']).toBe(
+            'is a string!'
+          );
+          return stored.remove(conn, name);
+        });
+    });
     it('fails if the body is not correct', () =>
       stored
         .create(conn, {
@@ -40,7 +63,7 @@ describe('stored', () => {
           query: 'select distinct ?type {?s a ?type}',
         })
         .then(res => {
-          expect(res.status).toBe(400);
+          expect(res.status).toBe(500);
         }));
   });
   describe('list()', () => {

--- a/test/stored.spec.js
+++ b/test/stored.spec.js
@@ -115,8 +115,8 @@ describe('stored', () => {
               query: newQuery,
               annotations: { 'iri:annotation:thing': 'is a new string!' },
             }),
-            true,
-            { contentType: 'application/ld+json' }
+            { contentType: 'application/ld+json' },
+            true
           );
         })
         .then(res => {

--- a/test/stored.spec.js
+++ b/test/stored.spec.js
@@ -12,6 +12,49 @@ const {
   ConnectionFactory,
 } = require('./setup-database');
 
+const convertToJsonLd = (conn, storedQuery) => {
+  const types = ['system:StoredQuery'];
+  if (storedQuery.shared) {
+    types.push('system:SharedQuery');
+  }
+  if (storedQuery.reasoning) {
+    types.push('system:ReasoningQuery');
+  }
+
+  const keyValuePairs = Object.entries(
+    Object.assign(
+      {
+        'system:queryName': storedQuery.name,
+        'system:queryDescription': storedQuery.description,
+        'system:queryString': storedQuery.query,
+        'system:queryCreator': conn.username,
+        'system:queryDatabase': storedQuery.database,
+      },
+      storedQuery.annotations
+    )
+  ).reduce((obj, [iri, value]) => {
+    if (typeof value !== 'undefined') {
+      obj[iri] = { '@value': value };
+    }
+    return obj;
+  }, {});
+
+  return {
+    '@context': {
+      system: 'http://system.stardog.com/',
+    },
+    '@graph': [
+      Object.assign(
+        {
+          '@id': 'system:Query',
+          '@type': types,
+        },
+        keyValuePairs
+      ),
+    ],
+  };
+};
+
 describe('stored', () => {
   const database = generateDatabaseName();
   const conn = ConnectionFactory();
@@ -33,26 +76,63 @@ describe('stored', () => {
           return stored.remove(conn, name);
         });
     });
-    it('allows annotations to be set', () => {
+    it.only('creates and updates a new stored query with annotations (using jsonld)', () => {
       const name = generateRandomString();
+      const query = 'select distinct ?type { ?s a ?type }';
+      const newQuery = 'select * { ?a ?b ?c }';
+
       return stored
-        .create(conn, {
-          name,
-          database,
-          query: 'select distinct ?type {?s a ?type}',
-          annotations: { 'iri:annotation:thing': 'is a string!' },
+        .create(
+          conn,
+          convertToJsonLd(conn, {
+            name,
+            database,
+            query,
+            annotations: { 'iri:annotation:thing': 'is a string!' },
+          }),
+          { contentType: 'application/ld+json' }
+        )
+        .then(res => {
+          expect(res.status).toBe(204);
+          return stored.list(conn, { accept: 'application/ld+json' });
+        })
+        .then(res => {
+          expect(res.status).toBe(200);
+          const storedQuery = res.body['@graph'].find(
+            v => v['system:queryName']['@value'] === name
+          );
+          expect(storedQuery).toBeTruthy();
+          expect(storedQuery['iri:annotation:thing']['@value']).toBe(
+            'is a string!'
+          );
+          expect(storedQuery['system:queryString']['@value']).toBe(query);
+
+          return stored.update(
+            conn,
+            convertToJsonLd(conn, {
+              name,
+              database,
+              query: newQuery,
+              annotations: { 'iri:annotation:thing': 'is a new string!' },
+            }),
+            true,
+            { contentType: 'application/ld+json' }
+          );
         })
         .then(res => {
           expect(res.status).toBe(204);
           return stored.list(conn, { accept: 'application/ld+json' });
         })
         .then(res => {
+          expect(res.status).toBe(200);
           const storedQuery = res.body['@graph'].find(
             v => v['system:queryName']['@value'] === name
           );
+          expect(storedQuery).toBeTruthy();
           expect(storedQuery['iri:annotation:thing']['@value']).toBe(
-            'is a string!'
+            'is a new string!'
           );
+          expect(storedQuery['system:queryString']['@value']).toBe(newQuery);
           return stored.remove(conn, name);
         });
     });
@@ -63,7 +143,7 @@ describe('stored', () => {
           query: 'select distinct ?type {?s a ?type}',
         })
         .then(res => {
-          expect(res.status).toBe(500);
+          expect(res.status).toBe(400);
         }));
   });
   describe('list()', () => {

--- a/test/stored.spec.js
+++ b/test/stored.spec.js
@@ -76,7 +76,7 @@ describe('stored', () => {
           return stored.remove(conn, name);
         });
     });
-    it.only('creates and updates a new stored query with annotations (using jsonld)', () => {
+    it('creates and updates a new stored query with annotations (using jsonld)', () => {
       const name = generateRandomString();
       const query = 'select distinct ?type { ?s a ?type }';
       const newQuery = 'select * { ?a ?b ?c }';


### PR DESCRIPTION
VET-2831

* ~~now using the jsonld style because the json type is deprecated in stardog, and doesn't return or accept annotations~~
* removed the `params` args; what was this even used for?

in order to return the extra fields on stored queries you have to change `accept` on `stored.list` to use something besides json:
```js
stored.list(conn, { accept: 'application/ld+json' });
```
but note that this now returns jsonld and not simple json!