### PR TITLE
[VET-7216] Add search and limit params to dataSources.getTables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2486,7 +2486,7 @@ Expects the following parameters:
 
 Returns [`Promise<HTTP.Body>`](#body)
 
-#### <a name="gettables">`dataSources.getTables(conn, name, options)`</a>
+#### <a name="gettables">`dataSources.getTables(conn, name, params)`</a>
 
 Retrieve tables
 
@@ -2496,7 +2496,7 @@ Expects the following parameters:
 
 - name (`string`)
 
-- options (`object`)
+- params (`object`)
 
 Returns [`Promise<HTTP.Body>`](#body)
 

--- a/lib/dataSources.js
+++ b/lib/dataSources.js
@@ -148,11 +148,17 @@ const getTableMetadata = (conn, dsName, opts) => {
   ).then(httpBody);
 };
 
-const getTables = (conn, name) => {
+const getTables = (conn, name, params = {}) => {
   const headers = conn.headers();
-  return fetch(conn.request('admin', 'data_sources', name, 'tables'), {
-    headers,
-  }).then(httpBody);
+  return fetch(
+    conn.request(
+      'admin',
+      'data_sources',
+      name,
+      `tables${encodeQueryString(params)}`
+    ),
+    { headers }
+  ).then(httpBody);
 };
 
 const updateMetadata = (conn, name, metadata, opts = {}) => {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2071,12 +2071,12 @@ declare namespace Stardog {
      *
      * @param {Connection} conn the Stardog server connection
      * @param {string} name the data source name
-     * @param {object} options additional options if needed
+     * @param {object} params optional `search` and `limit` query parameters; `search` is a case-insensitive substring matched against the table name, and `limit` caps how many tables are returned. `limit` must be a non-negative integer; the response carries no truncation flag, so request `limit + 1` to detect whether more tables exist
      */
     function getTables(
       conn: Connection,
       name: string,
-      options: object
+      params?: object
     ): Promise<HTTP.Body>;
 
     /**

--- a/test/dataSources.spec.js
+++ b/test/dataSources.spec.js
@@ -221,13 +221,14 @@ describe('data_sources', () => {
           expect(res.body).toMatchSnapshot();
         }));
 
-    // `search` and `limit` are ignored by servers that don't implement them,
-    // which would make a filtering assertion fail against a released Stardog.
-    // These only cover that the request is accepted and the shape is intact;
-    // the filtering semantics belong with the server that supports them. Like
-    // the rest of this file, they only run once a real MySQL data source exists
-    // and the `.only` above is lifted — the params themselves are covered by
-    // `getTables request URL`.
+    // A server that doesn't implement `search` and `limit` ignores them and
+    // returns every table, so these assert only what holds either way: the
+    // request is accepted and the shape is intact. Asserting the cap or the
+    // filter here fails against such a server as soon as the data source has
+    // more than one table. The params themselves are covered by `getTables
+    // request URL`; the filtering semantics belong with the server that
+    // supports them. Like the rest of this file, these only run once a real
+    // MySQL data source exists and the `.only` above is lifted.
     it('accepts a search term', () =>
       assureExists()
         .then(() => dataSources.getTables(conn, aDSName, { search: 'test' }))
@@ -241,7 +242,7 @@ describe('data_sources', () => {
         .then(() => dataSources.getTables(conn, aDSName, { limit: 1 }))
         .then(res => {
           expect(res.status).toBe(200);
-          expect(res.body.length).toBeLessThanOrEqual(1);
+          expect(Array.isArray(res.body)).toBe(true);
         }));
 
     it('accepts a search term and a limit together', () =>
@@ -251,7 +252,7 @@ describe('data_sources', () => {
         )
         .then(res => {
           expect(res.status).toBe(200);
-          expect(res.body.length).toBeLessThanOrEqual(1);
+          expect(Array.isArray(res.body)).toBe(true);
         }));
   });
 

--- a/test/dataSources.spec.js
+++ b/test/dataSources.spec.js
@@ -171,6 +171,36 @@ describe('data_sources', () => {
           expect(res.status).toBe(200);
           expect(res.body).toMatchSnapshot();
         }));
+
+    // `search` and `limit` are ignored by servers that don't implement them,
+    // which would make a filtering assertion fail against a released Stardog.
+    // These only cover that the request is accepted and the shape is intact;
+    // the filtering semantics belong with the server that supports them.
+    it('accepts a search term', () =>
+      assureExists()
+        .then(() => dataSources.getTables(conn, aDSName, { search: 'test' }))
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(Array.isArray(res.body)).toBe(true);
+        }));
+
+    it('accepts a limit', () =>
+      assureExists()
+        .then(() => dataSources.getTables(conn, aDSName, { limit: 1 }))
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.length).toBeLessThanOrEqual(1);
+        }));
+
+    it('accepts a search term and a limit together', () =>
+      assureExists()
+        .then(() =>
+          dataSources.getTables(conn, aDSName, { search: 'test', limit: 1 })
+        )
+        .then(res => {
+          expect(res.status).toBe(200);
+          expect(res.body.length).toBeLessThanOrEqual(1);
+        }));
   });
 
   describe('getTableMetadata', () => {

--- a/test/dataSources.spec.js
+++ b/test/dataSources.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 
+const { Connection } = require('../lib');
 const dataSources = require('../lib/dataSources');
 const { ConnectionFactory } = require('./setup-database');
 const snapshots = require('./__snapshots__/dataSources.spec.js.snap');
@@ -67,6 +68,54 @@ describe('data_sources', () => {
         expect(res.status).toBe(200);
         expect(Array.isArray(res.body.data_sources)).toBe(true);
       }));
+  });
+
+  // The `getTables` integration cases below can't tell a server that honors
+  // `search` and `limit` from one that ignores them, so the query string is
+  // asserted here against a stubbed fetch instead. Focused like `listInfo` so
+  // it runs without the MySQL data source the rest of this file needs.
+  // eslint-disable-next-line no-restricted-properties, jest/no-focused-tests
+  describe.only('getTables request URL', () => {
+    const stubConn = new Connection({
+      username: 'admin',
+      password: 'admin',
+      endpoint: 'http://localhost:5820',
+    });
+    const tablesUrl = `http://localhost:5820/admin/data_sources/${aDSName}/tables`;
+    let fetchSpy;
+
+    beforeEach(() => {
+      fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+        status: 200,
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve([]),
+      });
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('requests the bare tables path when no params are given', () =>
+      dataSources.getTables(stubConn, aDSName).then(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy.mock.calls[0][0]).toBe(tablesUrl);
+      }));
+
+    it('requests the bare tables path when params are empty', () =>
+      dataSources.getTables(stubConn, aDSName, {}).then(() => {
+        expect(fetchSpy.mock.calls[0][0]).toBe(tablesUrl);
+      }));
+
+    it('appends search and limit to the tables path', () =>
+      dataSources
+        .getTables(stubConn, aDSName, { search: 'a b&c', limit: 1000 })
+        .then(() => {
+          expect(fetchSpy.mock.calls[0][0]).toBe(
+            `${tablesUrl}?search=a%20b%26c&limit=1000`
+          );
+        }));
   });
 
   describe('info', () => {
@@ -175,7 +224,10 @@ describe('data_sources', () => {
     // `search` and `limit` are ignored by servers that don't implement them,
     // which would make a filtering assertion fail against a released Stardog.
     // These only cover that the request is accepted and the shape is intact;
-    // the filtering semantics belong with the server that supports them.
+    // the filtering semantics belong with the server that supports them. Like
+    // the rest of this file, they only run once a real MySQL data source exists
+    // and the `.only` above is lifted — the params themselves are covered by
+    // `getTables request URL`.
     it('accepts a search term', () =>
       assureExists()
         .then(() => dataSources.getTables(conn, aDSName, { search: 'test' }))

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -2,9 +2,8 @@
 
 const { encodeQueryString } = require('../lib/utils');
 
-// The query string built for the data source `tables` request; the no-param
-// case must stay byte-identical to the URL built before `search` and `limit`
-// existed.
+// The helper itself; the URLs it is used to build are asserted in
+// `dataSources.spec.js`.
 describe('encodeQueryString', () => {
   it('produces no query string when no params are given', () => {
     expect(encodeQueryString({})).toBe('');

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+
+const { encodeQueryString } = require('../lib/utils');
+
+// The query string built for the data source `tables` request; the no-param
+// case must stay byte-identical to the URL built before `search` and `limit`
+// existed.
+describe('encodeQueryString', () => {
+  it('produces no query string when no params are given', () => {
+    expect(encodeQueryString({})).toBe('');
+  });
+
+  it('serializes a search term and a limit together', () => {
+    expect(encodeQueryString({ search: 'cust', limit: 1000 })).toBe(
+      '?search=cust&limit=1000'
+    );
+  });
+
+  it('uri-encodes search terms containing spaces and separators', () => {
+    expect(encodeQueryString({ search: 'a b&c' })).toBe('?search=a%20b%26c');
+  });
+});


### PR DESCRIPTION
## Summary
`dataSources.getTables` can now pass `search` and `limit` query parameters to the server, so a caller can fetch a filtered/capped slice of a schema's tables instead of the whole list. This is the stardog.js slice of [VET-7216](https://stardog.atlassian.net/browse/VET-7216) (large-schema support in Studio's "Select tables" panel) — no Studio code here.

## What changed
- [`getTables`](https://github.com/stardog-union/stardog.js/blob/6a8af892226871b43a656e042208e6405fe95b14/lib/dataSources.js#L151) takes an optional third argument and serializes it onto the URL with the existing [`encodeQueryString`](https://github.com/stardog-union/stardog.js/blob/6a8af892226871b43a656e042208e6405fe95b14/lib/utils.js#L14), the same way [`remove`](https://github.com/stardog-union/stardog.js/blob/6a8af892226871b43a656e042208e6405fe95b14/lib/dataSources.js#L58) already does. With no params the helper returns `''`, so the request URL is unchanged for every existing caller.
- Type signature: `options: object` (required, and previously **ignored** by the implementation) → `params?: object` (optional, and now actually sent). JSDoc documents what the server accepts and the `limit + 1` trick for detecting truncation.
- README's API entry is regenerated from `lib/index.d.ts` (`yarn run docs`) — that diff is generated, not hand-edited.
- Tests: integration cases asserting the new params are *accepted* and the response shape holds; plus a new `test/utils.spec.js` unit file pinning `encodeQueryString`, including the empty-params case that guarantees URL identity.

## Acceptance criteria ([VET-7216](https://stardog.atlassian.net/browse/VET-7216))
Only the one stardog.js bullet under "Scope" applies; the rest of the ticket is Studio-side.
- [x] A caller can narrow a schema's table list by name substring and cap the number returned.
- [x] Omitting the params leaves behavior byte-identical to before, so small schemas and existing callers are untouched.
- [ ] Response shaped `{ tables, truncated }` — **not delivered here.** The endpoint still returns a bare array with no truncation flag; that depends on the backend work (PLAT-9177). Documented workaround in the JSDoc: request `limit + 1` and treat the extra row as "more exist".

## How to verify
**Setup:** a local Stardog server running (see README → Development), then `yarn install && yarn test` (lint + unit/integration).
- Call `getTables(conn, name)` with no third arg and confirm the request URL is still `/admin/data_sources/<name>/tables` with no `?` — this is the compatibility guarantee.
- Call with `{ search: 'a b&c' }` and confirm the URL encodes to `?search=a%20b%26c` (covered by `test/utils.spec.js`).
- Against a server that actually implements the params, confirm filtering and the cap take effect. The integration tests here deliberately **don't** assert filtering, because a released Stardog ignores unknown query params and the assertion would fail — see the comment above those tests.
- `yarn run docs` should produce no README diff.

## Notes for reviewers
- **Blast radius worth a look:** the third argument previously existed in the `.d.ts` but was silently dropped by the JS. Anything that was passing a placeholder object to satisfy the type will now have that object serialized into the query string. Worth a grep in Studio before merge.
- Making the param optional is source-compatible for TS consumers (loosening a required arg), so this isn't a breaking type change.
- The `truncated` flag the ticket's AC calls for is a backend concern; if PLAT-9177 lands with a different shape, the JSDoc guidance here needs updating too.


[VET-7216]: https://stardog.atlassian.net/browse/VET-7216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VET-7216]: https://stardog.atlassian.net/browse/VET-7216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ